### PR TITLE
fix(ci): scope workflow permissions to job level with actions: write

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
@@ -17,6 +14,9 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     services:
       postgres:
         image: postgres:16


### PR DESCRIPTION
Fixes a code scanning alert for missing explicit permissions. The initial fix applied `contents: read` at the workflow level, which silently drops all other token scopes to `none` — breaking `actions/upload-artifact@v4` and npm cache saves in `actions/setup-node@v4` with 403 errors.

## Summary

Move the `permissions` block from workflow level to job level on `jobs.test`, adding `actions: write` alongside `contents: read` to satisfy both the security requirement and the artifact/cache upload needs.

## Changes

- Removed workflow-level `permissions: contents: read`
- Added job-level `permissions` block to `jobs.test`:
  ```yaml
  permissions:
    contents: read   # satisfies least-privilege alert (checkout)
    actions: write   # required for upload-artifact and npm cache
  ```

## Test Plan

- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run build` passes
- [ ] Tested manually in the browser (describe what you clicked through)
- [ ] E2E tests added or updated (if applicable)

## Related Issues

<!-- Closes #123 -->