### PR TITLE
chore(release): v0.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.5.10] - 2026-04-13
+
+### Features
+- feature/openai codex oauth (#73) (481aad7)
+
+**Full Changelog**: https://github.com/sw-carlos-cristobal/sharetab/compare/v0.5.9...v0.5.10
+
 ## [v0.4.3] - 2026-04-06
 
 ### Other Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [v0.5.10] - 2026-04-13
 
 ### Features
-- feature/openai codex oauth (#73) (481aad7)
+- add OpenAI Codex OAuth support (#73) (481aad7)
 
 **Full Changelog**: https://github.com/sw-carlos-cristobal/sharetab/compare/v0.4.3...v0.5.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 - feature/openai codex oauth (#73) (481aad7)
 
-**Full Changelog**: https://github.com/sw-carlos-cristobal/sharetab/compare/v0.5.9...v0.5.10
+**Full Changelog**: https://github.com/sw-carlos-cristobal/sharetab/compare/v0.4.3...v0.5.10
 
 ## [v0.4.3] - 2026-04-06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sharetab",
-  "version": "0.4.5",
+  "version": "0.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sharetab",
-      "version": "0.4.5",
+      "version": "0.5.10",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharetab",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Self-hosted, open-source Splitwise alternative with AI-powered receipt scanning",
   "author": "Carlos Cristobal",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump version to v0.5.10
- update package-lock version metadata
- add changelog entry for v0.5.10

## Notes
- direct push to main is blocked by branch protection, so this release bump is proposed via PR
