### PR TITLE
feat(i18n): add translations for 6 new languages

### DIFF
--- a/messages/de/admin.json
+++ b/messages/de/admin.json
@@ -1,0 +1,24 @@
+{
+  "title": "Verwaltung",
+  "users": {
+    "title": "Benutzer",
+    "total": "Benutzer gesamt",
+    "active": "Aktiv",
+    "suspended": "Gesperrt"
+  },
+  "registration": {
+    "title": "Registrierung",
+    "mode": "Registrierungsmodus",
+    "open": "Offen",
+    "inviteOnly": "Nur mit Einladung",
+    "closed": "Geschlossen"
+  },
+  "activity": {
+    "title": "Aktivität",
+    "noActivity": "Keine aktuelle Aktivität"
+  },
+  "audit": {
+    "title": "Prüfprotokoll",
+    "noEntries": "Keine Protokolleinträge"
+  }
+}

--- a/messages/de/auth.json
+++ b/messages/de/auth.json
@@ -1,0 +1,64 @@
+{
+  "login": {
+    "title": "Willkommen zurück",
+    "subtitle": "Melden Sie sich bei Ihrem ShareTab-Konto an",
+    "email": "E-Mail",
+    "emailPlaceholder": "name@beispiel.de",
+    "password": "Passwort",
+    "passwordPlaceholder": "••••••••",
+    "submit": "Anmelden",
+    "submitting": "Anmeldung...",
+    "forgotPassword": "Passwort vergessen?",
+    "or": "oder",
+    "magicLink": "Mit E-Mail-Link anmelden",
+    "magicLinkDescription": "Wir senden Ihnen einen Link zur Anmeldung ohne Passwort. Sie können Ihr Passwort nach der Anmeldung in den Einstellungen ändern.",
+    "magicLinkEmail": "E-Mail",
+    "magicLinkSubmit": "Link senden",
+    "magicLinkSending": "Senden...",
+    "magicLinkError": "Link konnte nicht gesendet werden. Ist E-Mail konfiguriert?",
+    "passwordLink": "Mit Passwort anmelden",
+    "noAccount": "Noch kein Konto?",
+    "createAccount": "Konto erstellen",
+    "quickSplit": "Nur eine Rechnung teilen?",
+    "quickSplitLink": "Ohne Konto teilen",
+    "error": "Ungültige E-Mail oder ungültiges Passwort"
+  },
+  "register": {
+    "title": "Konto erstellen",
+    "subtitle": "Beginnen Sie, Ausgaben mit Freunden zu teilen",
+    "name": "Name",
+    "namePlaceholder": "Ihr Name",
+    "email": "E-Mail",
+    "emailPlaceholder": "name@beispiel.de",
+    "password": "Passwort",
+    "passwordPlaceholder": "Mindestens 8 Zeichen",
+    "inviteCode": "Einladungscode",
+    "inviteCodePlaceholder": "Einladungscode eingeben",
+    "submit": "Konto erstellen",
+    "submitting": "Erstellen...",
+    "hasAccount": "Bereits ein Konto?",
+    "signIn": "Anmelden",
+    "error": {
+      "emailTaken": "Ein Konto mit dieser E-Mail-Adresse existiert bereits.",
+      "inviteRequired": "Für die Registrierung ist ein Einladungscode erforderlich.",
+      "inviteInvalid": "Ungültiger oder abgelaufener Einladungscode.",
+      "closed": "Die Registrierung ist derzeit geschlossen.",
+      "generic": "Registrierung fehlgeschlagen. Bitte versuchen Sie es erneut."
+    }
+  },
+  "verifyRequest": {
+    "title": "Prüfen Sie Ihre E-Mails",
+    "description": "Ein Anmeldelink wurde an Ihre E-Mail-Adresse gesendet.",
+    "instructions": "Klicken Sie auf den Link in der E-Mail, um sich anzumelden. Der Link läuft in 24 Stunden ab.",
+    "spamHint": "Falls Sie die E-Mail nicht sehen, prüfen Sie Ihren Spam-Ordner.",
+    "backToLogin": "Zurück zur Anmeldung"
+  },
+  "invite": {
+    "loading": "Laden...",
+    "title": "Gruppe beitreten",
+    "description": "Sie wurden eingeladen, einer Gruppe auf ShareTab beizutreten.",
+    "joining": "Beitreten...",
+    "accept": "Einladung annehmen",
+    "dashboard": "Zur Übersicht"
+  }
+}

--- a/messages/de/common.json
+++ b/messages/de/common.json
@@ -1,0 +1,38 @@
+{
+  "nav": {
+    "dashboard": "Übersicht",
+    "groups": "Gruppen",
+    "quickSplit": "Schnell teilen",
+    "settings": "Einstellungen",
+    "admin": "Verwaltung",
+    "signOut": "Abmelden",
+    "changeLanguage": "Sprache ändern"
+  },
+  "actions": {
+    "save": "Speichern",
+    "cancel": "Abbrechen",
+    "delete": "Löschen",
+    "edit": "Bearbeiten",
+    "create": "Erstellen",
+    "back": "Zurück",
+    "close": "Schließen",
+    "confirm": "Bestätigen",
+    "loading": "Laden...",
+    "saving": "Speichern...",
+    "submit": "Absenden"
+  },
+  "brand": {
+    "name": "ShareTab",
+    "tagline": "Selbst gehostete Ausgabenteilung mit KI-Belegerfassung"
+  },
+  "sponsor": {
+    "title": "ShareTab unterstützen",
+    "description": "ShareTab ist kostenlos und quelloffen. Wenn es Ihnen Zeit spart, unterstützen Sie die Entwicklung.",
+    "cta": "Auf GitHub sponsern"
+  },
+  "errors": {
+    "generic": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.",
+    "notFound": "Nicht gefunden",
+    "unauthorized": "Sie müssen angemeldet sein, um auf diese Seite zuzugreifen."
+  }
+}

--- a/messages/de/dashboard.json
+++ b/messages/de/dashboard.json
@@ -1,0 +1,18 @@
+{
+  "title": "Übersicht",
+  "youOwe": "Sie schulden",
+  "youAreOwed": "Ihnen wird geschuldet",
+  "owedToYouTitle": "Personen, die Ihnen schulden",
+  "youOweTitle": "Personen, denen Sie schulden",
+  "settledUp": "Alles ausgeglichen!",
+  "noGroups": "Noch keine Gruppen",
+  "noGroupsDescription": "Erstellen Sie eine Gruppe, um Ausgaben zu teilen.",
+  "createGroup": "Gruppe erstellen",
+  "viewAll": "Alle anzeigen",
+  "recentActivity": "Letzte Aktivität",
+  "noActivity": "Keine aktuelle Aktivität",
+  "groups": "Gruppen",
+  "showMore": "Mehr anzeigen",
+  "members": "{count, plural, one {# Mitglied} other {# Mitglieder}}",
+  "archivedGroups": "{count, plural, one {# archivierte Gruppe} other {# archivierte Gruppen}}"
+}

--- a/messages/de/expenses.json
+++ b/messages/de/expenses.json
@@ -1,0 +1,46 @@
+{
+  "new": {
+    "title": "Ausgabe hinzufügen",
+    "description": "Beschreibung",
+    "descriptionPlaceholder": "Wofür war das?",
+    "amount": "Betrag",
+    "amountPlaceholder": "0,00",
+    "paidBy": "Bezahlt von",
+    "date": "Datum",
+    "splitType": "Aufteilungsart",
+    "splitEqual": "Gleichmäßig",
+    "splitExact": "Genaue Beträge",
+    "splitPercentage": "Prozentual",
+    "splitShares": "Anteile",
+    "submit": "Ausgabe hinzufügen",
+    "submitting": "Hinzufügen..."
+  },
+  "edit": {
+    "title": "Ausgabe bearbeiten",
+    "submit": "Änderungen speichern",
+    "submitting": "Speichern..."
+  },
+  "detail": {
+    "paidBy": "Bezahlt von {name}",
+    "addedBy": "Hinzugefügt von {name}",
+    "date": "Datum",
+    "split": "Aufteilungsdetails",
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "deleteConfirm": "Diese Ausgabe löschen?"
+  },
+  "scan": {
+    "title": "Beleg scannen",
+    "upload": "Beleg hochladen",
+    "uploadDescription": "Fotografieren oder laden Sie ein Bild Ihres Belegs hoch",
+    "processing": "Beleg wird verarbeitet...",
+    "retry": "Erneut versuchen"
+  },
+  "splits": {
+    "selectAll": "Alle auswählen",
+    "deselectAll": "Alle abwählen",
+    "perPerson": "pro Person",
+    "remaining": "Verbleibend",
+    "total": "Gesamt"
+  }
+}

--- a/messages/de/groups.json
+++ b/messages/de/groups.json
@@ -1,0 +1,48 @@
+{
+  "title": "Gruppen",
+  "create": "Gruppe erstellen",
+  "new": {
+    "title": "Neue Gruppe erstellen",
+    "name": "Gruppenname",
+    "namePlaceholder": "z.\u00A0B. WG, Reise nach Paris",
+    "currency": "Währung",
+    "submit": "Gruppe erstellen",
+    "submitting": "Erstellen..."
+  },
+  "detail": {
+    "expenses": "Ausgaben",
+    "balances": "Salden",
+    "addExpense": "Ausgabe hinzufügen",
+    "scanReceipt": "Beleg scannen",
+    "settle": "Ausgleichen",
+    "noExpenses": "Noch keine Ausgaben",
+    "noExpensesDescription": "Fügen Sie eine Ausgabe hinzu, um loszulegen.",
+    "totalSpent": "Gesamtausgaben",
+    "youOwe": "Sie schulden {name}",
+    "owesYou": "{name} schuldet Ihnen",
+    "settledUp": "Ausgeglichen"
+  },
+  "settings": {
+    "title": "Gruppeneinstellungen",
+    "name": "Gruppenname",
+    "currency": "Währung",
+    "members": "Mitglieder",
+    "addMember": "Mitglied hinzufügen",
+    "removeMember": "Entfernen",
+    "deleteGroup": "Gruppe löschen",
+    "deleteConfirm": "Sind Sie sicher? Dies kann nicht rückgängig gemacht werden.",
+    "invite": "Einladungslink",
+    "copyLink": "Link kopieren",
+    "linkCopied": "Link kopiert!"
+  },
+  "settle": {
+    "title": "Ausgleichen",
+    "from": "Von",
+    "to": "An",
+    "amount": "Betrag",
+    "submit": "Ausgleich erfassen",
+    "submitting": "Erfassen..."
+  },
+  "empty": "Noch keine Gruppen",
+  "emptyDescription": "Erstellen Sie Ihre erste Gruppe, um Ausgaben mit Freunden zu teilen."
+}

--- a/messages/de/settings.json
+++ b/messages/de/settings.json
@@ -1,0 +1,23 @@
+{
+  "title": "Einstellungen",
+  "profile": {
+    "title": "Profil",
+    "email": "E-Mail",
+    "name": "Name",
+    "save": "Speichern",
+    "saving": "Speichern...",
+    "saved": "Profil aktualisiert!",
+    "language": "Sprache",
+    "languageDescription": "Wählen Sie Ihre bevorzugte Sprache"
+  },
+  "password": {
+    "title": "Passwort ändern",
+    "current": "Aktuelles Passwort",
+    "new": "Neues Passwort",
+    "confirm": "Neues Passwort bestätigen",
+    "mismatch": "Passwörter stimmen nicht überein",
+    "submit": "Passwort ändern",
+    "submitting": "Ändern...",
+    "success": "Passwort geändert!"
+  }
+}

--- a/messages/fr/admin.json
+++ b/messages/fr/admin.json
@@ -1,0 +1,24 @@
+{
+  "title": "Administration",
+  "users": {
+    "title": "Utilisateurs",
+    "total": "Total des utilisateurs",
+    "active": "Actifs",
+    "suspended": "Suspendus"
+  },
+  "registration": {
+    "title": "Inscription",
+    "mode": "Mode d'inscription",
+    "open": "Ouvert",
+    "inviteOnly": "Sur invitation uniquement",
+    "closed": "Fermé"
+  },
+  "activity": {
+    "title": "Activité",
+    "noActivity": "Aucune activité récente"
+  },
+  "audit": {
+    "title": "Journal d'audit",
+    "noEntries": "Aucune entrée d'audit"
+  }
+}

--- a/messages/fr/auth.json
+++ b/messages/fr/auth.json
@@ -1,0 +1,64 @@
+{
+  "login": {
+    "title": "Bon retour",
+    "subtitle": "Connectez-vous à votre compte ShareTab",
+    "email": "E-mail",
+    "emailPlaceholder": "vous@exemple.com",
+    "password": "Mot de passe",
+    "passwordPlaceholder": "••••••••",
+    "submit": "Se connecter",
+    "submitting": "Connexion...",
+    "forgotPassword": "Mot de passe oublié ?",
+    "or": "ou",
+    "magicLink": "Se connecter par lien e-mail",
+    "magicLinkDescription": "Nous vous enverrons un lien magique pour vous connecter sans mot de passe. Vous pourrez modifier votre mot de passe depuis les Paramètres une fois connecté.",
+    "magicLinkEmail": "E-mail",
+    "magicLinkSubmit": "Envoyer le lien magique",
+    "magicLinkSending": "Envoi...",
+    "magicLinkError": "Impossible d'envoyer le lien magique. L'e-mail est-il configuré ?",
+    "passwordLink": "Se connecter avec un mot de passe",
+    "noAccount": "Vous n'avez pas de compte ?",
+    "createAccount": "En créer un",
+    "quickSplit": "Vous voulez juste partager une note ?",
+    "quickSplitLink": "Partager sans compte",
+    "error": "E-mail ou mot de passe invalide"
+  },
+  "register": {
+    "title": "Créez votre compte",
+    "subtitle": "Commencez à partager vos dépenses entre amis",
+    "name": "Nom",
+    "namePlaceholder": "Votre nom",
+    "email": "E-mail",
+    "emailPlaceholder": "vous@exemple.com",
+    "password": "Mot de passe",
+    "passwordPlaceholder": "Au moins 8 caractères",
+    "inviteCode": "Code d'invitation",
+    "inviteCodePlaceholder": "Entrez votre code d'invitation",
+    "submit": "Créer un compte",
+    "submitting": "Création...",
+    "hasAccount": "Vous avez déjà un compte ?",
+    "signIn": "Se connecter",
+    "error": {
+      "emailTaken": "Un compte avec cet e-mail existe déjà.",
+      "inviteRequired": "Un code d'invitation est requis pour s'inscrire.",
+      "inviteInvalid": "Code d'invitation invalide ou expiré.",
+      "closed": "Les inscriptions sont actuellement fermées.",
+      "generic": "L'inscription a échoué. Veuillez réessayer."
+    }
+  },
+  "verifyRequest": {
+    "title": "Vérifiez vos e-mails",
+    "description": "Un lien de connexion a été envoyé à votre adresse e-mail.",
+    "instructions": "Cliquez sur le lien dans l'e-mail pour vous connecter. Le lien expirera dans 24 heures.",
+    "spamHint": "Si vous ne voyez pas l'e-mail, vérifiez votre dossier de courrier indésirable.",
+    "backToLogin": "Retour à la connexion"
+  },
+  "invite": {
+    "loading": "Chargement...",
+    "title": "Rejoindre le groupe",
+    "description": "Vous avez été invité à rejoindre un groupe sur ShareTab.",
+    "joining": "Rejoindre...",
+    "accept": "Accepter l'invitation",
+    "dashboard": "Aller au tableau de bord"
+  }
+}

--- a/messages/fr/common.json
+++ b/messages/fr/common.json
@@ -1,0 +1,38 @@
+{
+  "nav": {
+    "dashboard": "Tableau de bord",
+    "groups": "Groupes",
+    "quickSplit": "Partage rapide",
+    "settings": "Paramètres",
+    "admin": "Administration",
+    "signOut": "Se déconnecter",
+    "changeLanguage": "Changer de langue"
+  },
+  "actions": {
+    "save": "Enregistrer",
+    "cancel": "Annuler",
+    "delete": "Supprimer",
+    "edit": "Modifier",
+    "create": "Créer",
+    "back": "Retour",
+    "close": "Fermer",
+    "confirm": "Confirmer",
+    "loading": "Chargement...",
+    "saving": "Enregistrement...",
+    "submit": "Envoyer"
+  },
+  "brand": {
+    "name": "ShareTab",
+    "tagline": "Partage de dépenses auto-hébergé avec scan de reçus par IA"
+  },
+  "sponsor": {
+    "title": "Soutenir ShareTab",
+    "description": "ShareTab est gratuit et open source. S'il vous fait gagner du temps, pensez à soutenir son développement.",
+    "cta": "Sponsoriser sur GitHub"
+  },
+  "errors": {
+    "generic": "Une erreur est survenue. Veuillez réessayer.",
+    "notFound": "Introuvable",
+    "unauthorized": "Vous devez être connecté pour accéder à cette page."
+  }
+}

--- a/messages/fr/dashboard.json
+++ b/messages/fr/dashboard.json
@@ -3,7 +3,7 @@
   "youOwe": "Vous devez",
   "youAreOwed": "On vous doit",
   "owedToYouTitle": "Personnes qui vous doivent",
-  "youOweTitle": "Personnes que vous devez",
+  "youOweTitle": "Personnes à qui vous devez",
   "settledUp": "Tout est réglé !",
   "noGroups": "Aucun groupe",
   "noGroupsDescription": "Créez un groupe pour commencer à partager les dépenses.",

--- a/messages/fr/dashboard.json
+++ b/messages/fr/dashboard.json
@@ -1,0 +1,18 @@
+{
+  "title": "Tableau de bord",
+  "youOwe": "Vous devez",
+  "youAreOwed": "On vous doit",
+  "owedToYouTitle": "Personnes qui vous doivent",
+  "youOweTitle": "Personnes que vous devez",
+  "settledUp": "Tout est réglé !",
+  "noGroups": "Aucun groupe",
+  "noGroupsDescription": "Créez un groupe pour commencer à partager les dépenses.",
+  "createGroup": "Créer un groupe",
+  "viewAll": "Tout voir",
+  "recentActivity": "Activité récente",
+  "noActivity": "Aucune activité récente",
+  "groups": "Groupes",
+  "showMore": "Voir plus",
+  "members": "{count, plural, one {# membre} other {# membres}}",
+  "archivedGroups": "{count, plural, one {# groupe archivé} other {# groupes archivés}}"
+}

--- a/messages/fr/expenses.json
+++ b/messages/fr/expenses.json
@@ -1,0 +1,46 @@
+{
+  "new": {
+    "title": "Ajouter une dépense",
+    "description": "Description",
+    "descriptionPlaceholder": "À quoi correspond cette dépense ?",
+    "amount": "Montant",
+    "amountPlaceholder": "0,00",
+    "paidBy": "Payé par",
+    "date": "Date",
+    "splitType": "Type de partage",
+    "splitEqual": "Égal",
+    "splitExact": "Montants exacts",
+    "splitPercentage": "Pourcentage",
+    "splitShares": "Parts",
+    "submit": "Ajouter la dépense",
+    "submitting": "Ajout..."
+  },
+  "edit": {
+    "title": "Modifier la dépense",
+    "submit": "Enregistrer les modifications",
+    "submitting": "Enregistrement..."
+  },
+  "detail": {
+    "paidBy": "Payé par {name}",
+    "addedBy": "Ajouté par {name}",
+    "date": "Date",
+    "split": "Détails du partage",
+    "edit": "Modifier",
+    "delete": "Supprimer",
+    "deleteConfirm": "Supprimer cette dépense ?"
+  },
+  "scan": {
+    "title": "Scanner un reçu",
+    "upload": "Envoyer un reçu",
+    "uploadDescription": "Prenez une photo ou envoyez une image de votre reçu",
+    "processing": "Traitement du reçu...",
+    "retry": "Réessayer"
+  },
+  "splits": {
+    "selectAll": "Tout sélectionner",
+    "deselectAll": "Tout désélectionner",
+    "perPerson": "par personne",
+    "remaining": "Restant",
+    "total": "Total"
+  }
+}

--- a/messages/fr/groups.json
+++ b/messages/fr/groups.json
@@ -1,0 +1,48 @@
+{
+  "title": "Groupes",
+  "create": "Créer un groupe",
+  "new": {
+    "title": "Créer un nouveau groupe",
+    "name": "Nom du groupe",
+    "namePlaceholder": "ex. Appartement, Voyage à Paris",
+    "currency": "Devise",
+    "submit": "Créer le groupe",
+    "submitting": "Création..."
+  },
+  "detail": {
+    "expenses": "Dépenses",
+    "balances": "Soldes",
+    "addExpense": "Ajouter une dépense",
+    "scanReceipt": "Scanner un reçu",
+    "settle": "Régler les comptes",
+    "noExpenses": "Aucune dépense",
+    "noExpensesDescription": "Ajoutez une dépense pour commencer.",
+    "totalSpent": "Total dépensé",
+    "youOwe": "Vous devez à {name}",
+    "owesYou": "{name} vous doit",
+    "settledUp": "Comptes réglés"
+  },
+  "settings": {
+    "title": "Paramètres du groupe",
+    "name": "Nom du groupe",
+    "currency": "Devise",
+    "members": "Membres",
+    "addMember": "Ajouter un membre",
+    "removeMember": "Retirer",
+    "deleteGroup": "Supprimer le groupe",
+    "deleteConfirm": "Êtes-vous sûr ? Cette action est irréversible.",
+    "invite": "Lien d'invitation",
+    "copyLink": "Copier le lien",
+    "linkCopied": "Lien copié !"
+  },
+  "settle": {
+    "title": "Régler les comptes",
+    "from": "De",
+    "to": "À",
+    "amount": "Montant",
+    "submit": "Enregistrer le règlement",
+    "submitting": "Enregistrement..."
+  },
+  "empty": "Aucun groupe",
+  "emptyDescription": "Créez votre premier groupe pour commencer à partager les dépenses entre amis."
+}

--- a/messages/fr/settings.json
+++ b/messages/fr/settings.json
@@ -1,0 +1,23 @@
+{
+  "title": "Paramètres",
+  "profile": {
+    "title": "Profil",
+    "email": "E-mail",
+    "name": "Nom",
+    "save": "Enregistrer",
+    "saving": "Enregistrement...",
+    "saved": "Profil mis à jour !",
+    "language": "Langue",
+    "languageDescription": "Choisissez votre langue préférée"
+  },
+  "password": {
+    "title": "Changer le mot de passe",
+    "current": "Mot de passe actuel",
+    "new": "Nouveau mot de passe",
+    "confirm": "Confirmer le nouveau mot de passe",
+    "mismatch": "Les mots de passe ne correspondent pas",
+    "submit": "Changer le mot de passe",
+    "submitting": "Modification...",
+    "success": "Mot de passe modifié !"
+  }
+}

--- a/messages/ja/admin.json
+++ b/messages/ja/admin.json
@@ -1,0 +1,24 @@
+{
+  "title": "管理",
+  "users": {
+    "title": "ユーザー",
+    "total": "ユーザー総数",
+    "active": "アクティブ",
+    "suspended": "停止中"
+  },
+  "registration": {
+    "title": "登録",
+    "mode": "登録モード",
+    "open": "オープン",
+    "inviteOnly": "招待制",
+    "closed": "停止中"
+  },
+  "activity": {
+    "title": "アクティビティ",
+    "noActivity": "最近のアクティビティはありません"
+  },
+  "audit": {
+    "title": "監査ログ",
+    "noEntries": "監査エントリはありません"
+  }
+}

--- a/messages/ja/auth.json
+++ b/messages/ja/auth.json
@@ -1,0 +1,64 @@
+{
+  "login": {
+    "title": "おかえりなさい",
+    "subtitle": "ShareTabアカウントにログイン",
+    "email": "メールアドレス",
+    "emailPlaceholder": "you@example.com",
+    "password": "パスワード",
+    "passwordPlaceholder": "••••••••",
+    "submit": "ログイン",
+    "submitting": "ログイン中...",
+    "forgotPassword": "パスワードをお忘れですか?",
+    "or": "または",
+    "magicLink": "メールリンクでログイン",
+    "magicLinkDescription": "パスワードなしでログインできるマジックリンクをお送りします。ログイン後、設定からパスワードを変更できます。",
+    "magicLinkEmail": "メールアドレス",
+    "magicLinkSubmit": "マジックリンクを送信",
+    "magicLinkSending": "送信中...",
+    "magicLinkError": "マジックリンクを送信できませんでした。メール設定をご確認ください。",
+    "passwordLink": "パスワードでログイン",
+    "noAccount": "アカウントをお持ちでないですか?",
+    "createAccount": "新規登録",
+    "quickSplit": "割り勘だけしたいですか?",
+    "quickSplitLink": "アカウントなしで割り勘",
+    "error": "メールアドレスまたはパスワードが正しくありません"
+  },
+  "register": {
+    "title": "アカウントを作成",
+    "subtitle": "友達との割り勘を始めましょう",
+    "name": "名前",
+    "namePlaceholder": "お名前",
+    "email": "メールアドレス",
+    "emailPlaceholder": "you@example.com",
+    "password": "パスワード",
+    "passwordPlaceholder": "8文字以上",
+    "inviteCode": "招待コード",
+    "inviteCodePlaceholder": "招待コードを入力",
+    "submit": "アカウントを作成",
+    "submitting": "作成中...",
+    "hasAccount": "すでにアカウントをお持ちですか?",
+    "signIn": "ログイン",
+    "error": {
+      "emailTaken": "このメールアドレスは既に登録されています。",
+      "inviteRequired": "登録には招待コードが必要です。",
+      "inviteInvalid": "招待コードが無効または期限切れです。",
+      "closed": "現在、新規登録は受け付けていません。",
+      "generic": "登録に失敗しました。もう一度お試しください。"
+    }
+  },
+  "verifyRequest": {
+    "title": "メールをご確認ください",
+    "description": "ログインリンクをメールアドレスに送信しました。",
+    "instructions": "メール内のリンクをクリックしてログインしてください。リンクの有効期限は24時間です。",
+    "spamHint": "メールが届かない場合は、迷惑メールフォルダをご確認ください。",
+    "backToLogin": "ログインに戻る"
+  },
+  "invite": {
+    "loading": "読み込み中...",
+    "title": "グループに参加",
+    "description": "ShareTabのグループに招待されています。",
+    "joining": "参加中...",
+    "accept": "招待を受ける",
+    "dashboard": "ダッシュボードへ"
+  }
+}

--- a/messages/ja/common.json
+++ b/messages/ja/common.json
@@ -1,0 +1,38 @@
+{
+  "nav": {
+    "dashboard": "ダッシュボード",
+    "groups": "グループ",
+    "quickSplit": "かんたん割り勘",
+    "settings": "設定",
+    "admin": "管理",
+    "signOut": "ログアウト",
+    "changeLanguage": "言語を変更"
+  },
+  "actions": {
+    "save": "保存",
+    "cancel": "キャンセル",
+    "delete": "削除",
+    "edit": "編集",
+    "create": "作成",
+    "back": "戻る",
+    "close": "閉じる",
+    "confirm": "確認",
+    "loading": "読み込み中...",
+    "saving": "保存中...",
+    "submit": "送信"
+  },
+  "brand": {
+    "name": "ShareTab",
+    "tagline": "AIレシート読み取り機能付きのセルフホスト型割り勘アプリ"
+  },
+  "sponsor": {
+    "title": "ShareTabを応援する",
+    "description": "ShareTabは無料のオープンソースです。お役に立てましたら、開発のスポンサーをご検討ください。",
+    "cta": "GitHubでスポンサーになる"
+  },
+  "errors": {
+    "generic": "問題が発生しました。もう一度お試しください。",
+    "notFound": "見つかりません",
+    "unauthorized": "このページにアクセスするにはログインが必要です。"
+  }
+}

--- a/messages/ja/dashboard.json
+++ b/messages/ja/dashboard.json
@@ -1,0 +1,18 @@
+{
+  "title": "ダッシュボード",
+  "youOwe": "あなたの支払い",
+  "youAreOwed": "あなたへの支払い",
+  "owedToYouTitle": "あなたに借りがある人",
+  "youOweTitle": "あなたが借りている人",
+  "settledUp": "すべて精算済みです!",
+  "noGroups": "グループがありません",
+  "noGroupsDescription": "グループを作成して割り勘を始めましょう。",
+  "createGroup": "グループを作成",
+  "viewAll": "すべて表示",
+  "recentActivity": "最近のアクティビティ",
+  "noActivity": "最近のアクティビティはありません",
+  "groups": "グループ",
+  "showMore": "もっと見る",
+  "members": "{count, plural, other {#人のメンバー}}",
+  "archivedGroups": "{count, plural, other {#件のアーカイブ済みグループ}}"
+}

--- a/messages/ja/expenses.json
+++ b/messages/ja/expenses.json
@@ -1,0 +1,46 @@
+{
+  "new": {
+    "title": "支出を追加",
+    "description": "説明",
+    "descriptionPlaceholder": "何の支出ですか?",
+    "amount": "金額",
+    "amountPlaceholder": "0.00",
+    "paidBy": "支払った人",
+    "date": "日付",
+    "splitType": "割り勘の方法",
+    "splitEqual": "均等",
+    "splitExact": "金額指定",
+    "splitPercentage": "割合",
+    "splitShares": "比率",
+    "submit": "支出を追加",
+    "submitting": "追加中..."
+  },
+  "edit": {
+    "title": "支出を編集",
+    "submit": "変更を保存",
+    "submitting": "保存中..."
+  },
+  "detail": {
+    "paidBy": "{name}が支払い",
+    "addedBy": "{name}が追加",
+    "date": "日付",
+    "split": "割り勘の詳細",
+    "edit": "編集",
+    "delete": "削除",
+    "deleteConfirm": "この支出を削除しますか?"
+  },
+  "scan": {
+    "title": "レシートをスキャン",
+    "upload": "レシートをアップロード",
+    "uploadDescription": "レシートの写真を撮るか、画像をアップロードしてください",
+    "processing": "レシートを処理中...",
+    "retry": "もう一度試す"
+  },
+  "splits": {
+    "selectAll": "すべて選択",
+    "deselectAll": "すべて解除",
+    "perPerson": "一人あたり",
+    "remaining": "残り",
+    "total": "合計"
+  }
+}

--- a/messages/ja/groups.json
+++ b/messages/ja/groups.json
@@ -1,0 +1,48 @@
+{
+  "title": "グループ",
+  "create": "グループを作成",
+  "new": {
+    "title": "新しいグループを作成",
+    "name": "グループ名",
+    "namePlaceholder": "例: アパート、パリ旅行",
+    "currency": "通貨",
+    "submit": "グループを作成",
+    "submitting": "作成中..."
+  },
+  "detail": {
+    "expenses": "支出",
+    "balances": "残高",
+    "addExpense": "支出を追加",
+    "scanReceipt": "レシートをスキャン",
+    "settle": "精算する",
+    "noExpenses": "支出がありません",
+    "noExpensesDescription": "支出を追加して始めましょう。",
+    "totalSpent": "合計支出",
+    "youOwe": "あなたが{name}に支払う金額",
+    "owesYou": "{name}があなたに支払う金額",
+    "settledUp": "精算済み"
+  },
+  "settings": {
+    "title": "グループ設定",
+    "name": "グループ名",
+    "currency": "通貨",
+    "members": "メンバー",
+    "addMember": "メンバーを追加",
+    "removeMember": "削除",
+    "deleteGroup": "グループを削除",
+    "deleteConfirm": "本当に削除しますか?この操作は取り消せません。",
+    "invite": "招待リンク",
+    "copyLink": "リンクをコピー",
+    "linkCopied": "リンクをコピーしました!"
+  },
+  "settle": {
+    "title": "精算する",
+    "from": "支払い元",
+    "to": "支払い先",
+    "amount": "金額",
+    "submit": "精算を記録",
+    "submitting": "記録中..."
+  },
+  "empty": "グループがありません",
+  "emptyDescription": "最初のグループを作成して、友達との割り勘を始めましょう。"
+}

--- a/messages/ja/settings.json
+++ b/messages/ja/settings.json
@@ -1,0 +1,23 @@
+{
+  "title": "設定",
+  "profile": {
+    "title": "プロフィール",
+    "email": "メールアドレス",
+    "name": "名前",
+    "save": "保存",
+    "saving": "保存中...",
+    "saved": "プロフィールを更新しました!",
+    "language": "言語",
+    "languageDescription": "お好みの言語を選択してください"
+  },
+  "password": {
+    "title": "パスワードを変更",
+    "current": "現在のパスワード",
+    "new": "新しいパスワード",
+    "confirm": "新しいパスワード(確認)",
+    "mismatch": "パスワードが一致しません",
+    "submit": "パスワードを変更",
+    "submitting": "変更中...",
+    "success": "パスワードを変更しました!"
+  }
+}

--- a/messages/ko/admin.json
+++ b/messages/ko/admin.json
@@ -1,0 +1,24 @@
+{
+  "title": "관리자",
+  "users": {
+    "title": "사용자",
+    "total": "전체 사용자",
+    "active": "활성",
+    "suspended": "정지됨"
+  },
+  "registration": {
+    "title": "가입 설정",
+    "mode": "가입 방식",
+    "open": "공개",
+    "inviteOnly": "초대 전용",
+    "closed": "비공개"
+  },
+  "activity": {
+    "title": "활동",
+    "noActivity": "최근 활동이 없습니다"
+  },
+  "audit": {
+    "title": "감사 로그",
+    "noEntries": "감사 기록이 없습니다"
+  }
+}

--- a/messages/ko/auth.json
+++ b/messages/ko/auth.json
@@ -1,0 +1,64 @@
+{
+  "login": {
+    "title": "다시 오신 것을 환영합니다",
+    "subtitle": "ShareTab 계정에 로그인하세요",
+    "email": "이메일",
+    "emailPlaceholder": "you@example.com",
+    "password": "비밀번호",
+    "passwordPlaceholder": "••••••••",
+    "submit": "로그인",
+    "submitting": "로그인 중...",
+    "forgotPassword": "비밀번호를 잊으셨나요?",
+    "or": "또는",
+    "magicLink": "이메일 링크로 로그인",
+    "magicLinkDescription": "비밀번호 없이 로그인할 수 있는 매직 링크를 보내드립니다. 로그인 후 설정에서 비밀번호를 변경할 수 있습니다.",
+    "magicLinkEmail": "이메일",
+    "magicLinkSubmit": "매직 링크 보내기",
+    "magicLinkSending": "전송 중...",
+    "magicLinkError": "매직 링크를 보낼 수 없습니다. 이메일이 설정되어 있나요?",
+    "passwordLink": "비밀번호로 로그인",
+    "noAccount": "계정이 없으신가요?",
+    "createAccount": "계정 만들기",
+    "quickSplit": "비용만 나누고 싶으신가요?",
+    "quickSplitLink": "계정 없이 정산하기",
+    "error": "이메일 또는 비밀번호가 올바르지 않습니다"
+  },
+  "register": {
+    "title": "계정 만들기",
+    "subtitle": "친구들과 비용 분할을 시작하세요",
+    "name": "이름",
+    "namePlaceholder": "이름을 입력하세요",
+    "email": "이메일",
+    "emailPlaceholder": "you@example.com",
+    "password": "비밀번호",
+    "passwordPlaceholder": "8자 이상",
+    "inviteCode": "초대 코드",
+    "inviteCodePlaceholder": "초대 코드를 입력하세요",
+    "submit": "계정 만들기",
+    "submitting": "생성 중...",
+    "hasAccount": "이미 계정이 있으신가요?",
+    "signIn": "로그인",
+    "error": {
+      "emailTaken": "이미 사용 중인 이메일입니다.",
+      "inviteRequired": "가입하려면 초대 코드가 필요합니다.",
+      "inviteInvalid": "유효하지 않거나 만료된 초대 코드입니다.",
+      "closed": "현재 가입이 제한되어 있습니다.",
+      "generic": "가입에 실패했습니다. 다시 시도해 주세요."
+    }
+  },
+  "verifyRequest": {
+    "title": "이메일을 확인하세요",
+    "description": "로그인 링크가 이메일 주소로 전송되었습니다.",
+    "instructions": "이메일의 링크를 클릭하여 로그인하세요. 링크는 24시간 후에 만료됩니다.",
+    "spamHint": "이메일이 보이지 않으면 스팸 폴더를 확인해 주세요.",
+    "backToLogin": "로그인으로 돌아가기"
+  },
+  "invite": {
+    "loading": "로딩 중...",
+    "title": "그룹 참가",
+    "description": "ShareTab 그룹에 초대되었습니다.",
+    "joining": "참가 중...",
+    "accept": "초대 수락",
+    "dashboard": "대시보드로 이동"
+  }
+}

--- a/messages/ko/common.json
+++ b/messages/ko/common.json
@@ -1,0 +1,38 @@
+{
+  "nav": {
+    "dashboard": "대시보드",
+    "groups": "그룹",
+    "quickSplit": "빠른 정산",
+    "settings": "설정",
+    "admin": "관리자",
+    "signOut": "로그아웃",
+    "changeLanguage": "언어 변경"
+  },
+  "actions": {
+    "save": "저장",
+    "cancel": "취소",
+    "delete": "삭제",
+    "edit": "편집",
+    "create": "생성",
+    "back": "뒤로",
+    "close": "닫기",
+    "confirm": "확인",
+    "loading": "로딩 중...",
+    "saving": "저장 중...",
+    "submit": "제출"
+  },
+  "brand": {
+    "name": "ShareTab",
+    "tagline": "AI 영수증 스캔 기능을 갖춘 셀프 호스팅 비용 분할 서비스"
+  },
+  "sponsor": {
+    "title": "ShareTab 후원하기",
+    "description": "ShareTab은 무료 오픈 소스입니다. 유용하셨다면 개발 후원을 고려해 주세요.",
+    "cta": "GitHub에서 후원하기"
+  },
+  "errors": {
+    "generic": "문제가 발생했습니다. 다시 시도해 주세요.",
+    "notFound": "찾을 수 없습니다",
+    "unauthorized": "이 페이지에 접근하려면 로그인해야 합니다."
+  }
+}

--- a/messages/ko/dashboard.json
+++ b/messages/ko/dashboard.json
@@ -1,0 +1,18 @@
+{
+  "title": "대시보드",
+  "youOwe": "내가 갚을 금액",
+  "youAreOwed": "받을 금액",
+  "owedToYouTitle": "나에게 빚진 사람",
+  "youOweTitle": "내가 빚진 사람",
+  "settledUp": "모두 정산 완료!",
+  "noGroups": "그룹이 없습니다",
+  "noGroupsDescription": "비용 분할을 시작하려면 그룹을 만드세요.",
+  "createGroup": "그룹 만들기",
+  "viewAll": "모두 보기",
+  "recentActivity": "최근 활동",
+  "noActivity": "최근 활동이 없습니다",
+  "groups": "그룹",
+  "showMore": "더 보기",
+  "members": "{count, plural, other {#명}}",
+  "archivedGroups": "{count, plural, other {보관된 그룹 #개}}"
+}

--- a/messages/ko/expenses.json
+++ b/messages/ko/expenses.json
@@ -1,0 +1,46 @@
+{
+  "new": {
+    "title": "비용 추가",
+    "description": "설명",
+    "descriptionPlaceholder": "무엇에 대한 비용인가요?",
+    "amount": "금액",
+    "amountPlaceholder": "0.00",
+    "paidBy": "결제자",
+    "date": "날짜",
+    "splitType": "분할 방식",
+    "splitEqual": "균등 분할",
+    "splitExact": "금액 지정",
+    "splitPercentage": "비율",
+    "splitShares": "비율 분할",
+    "submit": "비용 추가",
+    "submitting": "추가 중..."
+  },
+  "edit": {
+    "title": "비용 편집",
+    "submit": "변경 사항 저장",
+    "submitting": "저장 중..."
+  },
+  "detail": {
+    "paidBy": "{name}이(가) 결제",
+    "addedBy": "{name}이(가) 추가",
+    "date": "날짜",
+    "split": "분할 내역",
+    "edit": "편집",
+    "delete": "삭제",
+    "deleteConfirm": "이 비용을 삭제하시겠습니까?"
+  },
+  "scan": {
+    "title": "영수증 스캔",
+    "upload": "영수증 업로드",
+    "uploadDescription": "영수증 사진을 촬영하거나 이미지를 업로드하세요",
+    "processing": "영수증 처리 중...",
+    "retry": "다시 시도"
+  },
+  "splits": {
+    "selectAll": "전체 선택",
+    "deselectAll": "전체 해제",
+    "perPerson": "1인당",
+    "remaining": "남은 금액",
+    "total": "합계"
+  }
+}

--- a/messages/ko/groups.json
+++ b/messages/ko/groups.json
@@ -1,0 +1,48 @@
+{
+  "title": "그룹",
+  "create": "그룹 만들기",
+  "new": {
+    "title": "새 그룹 만들기",
+    "name": "그룹 이름",
+    "namePlaceholder": "예: 아파트, 파리 여행",
+    "currency": "통화",
+    "submit": "그룹 만들기",
+    "submitting": "생성 중..."
+  },
+  "detail": {
+    "expenses": "비용",
+    "balances": "잔액",
+    "addExpense": "비용 추가",
+    "scanReceipt": "영수증 스캔",
+    "settle": "정산하기",
+    "noExpenses": "비용이 없습니다",
+    "noExpensesDescription": "비용을 추가하여 시작하세요.",
+    "totalSpent": "총 지출",
+    "youOwe": "{name}에게 갚을 금액",
+    "owesYou": "{name}이(가) 갚을 금액",
+    "settledUp": "정산 완료"
+  },
+  "settings": {
+    "title": "그룹 설정",
+    "name": "그룹 이름",
+    "currency": "통화",
+    "members": "멤버",
+    "addMember": "멤버 추가",
+    "removeMember": "제거",
+    "deleteGroup": "그룹 삭제",
+    "deleteConfirm": "정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+    "invite": "초대 링크",
+    "copyLink": "링크 복사",
+    "linkCopied": "링크가 복사되었습니다!"
+  },
+  "settle": {
+    "title": "정산하기",
+    "from": "보내는 사람",
+    "to": "받는 사람",
+    "amount": "금액",
+    "submit": "정산 기록",
+    "submitting": "기록 중..."
+  },
+  "empty": "그룹이 없습니다",
+  "emptyDescription": "친구들과 비용 분할을 시작하려면 첫 번째 그룹을 만드세요."
+}

--- a/messages/ko/settings.json
+++ b/messages/ko/settings.json
@@ -1,0 +1,23 @@
+{
+  "title": "설정",
+  "profile": {
+    "title": "프로필",
+    "email": "이메일",
+    "name": "이름",
+    "save": "저장",
+    "saving": "저장 중...",
+    "saved": "프로필이 업데이트되었습니다!",
+    "language": "언어",
+    "languageDescription": "선호하는 언어를 선택하세요"
+  },
+  "password": {
+    "title": "비밀번호 변경",
+    "current": "현재 비밀번호",
+    "new": "새 비밀번호",
+    "confirm": "새 비밀번호 확인",
+    "mismatch": "비밀번호가 일치하지 않습니다",
+    "submit": "비밀번호 변경",
+    "submitting": "변경 중...",
+    "success": "비밀번호가 변경되었습니다!"
+  }
+}

--- a/messages/pt-BR/admin.json
+++ b/messages/pt-BR/admin.json
@@ -1,0 +1,24 @@
+{
+  "title": "Admin",
+  "users": {
+    "title": "Usuários",
+    "total": "Total de usuários",
+    "active": "Ativos",
+    "suspended": "Suspensos"
+  },
+  "registration": {
+    "title": "Registro",
+    "mode": "Modo de registro",
+    "open": "Aberto",
+    "inviteOnly": "Somente com convite",
+    "closed": "Fechado"
+  },
+  "activity": {
+    "title": "Atividade",
+    "noActivity": "Nenhuma atividade recente"
+  },
+  "audit": {
+    "title": "Log de auditoria",
+    "noEntries": "Nenhum registro de auditoria"
+  }
+}

--- a/messages/pt-BR/auth.json
+++ b/messages/pt-BR/auth.json
@@ -1,0 +1,64 @@
+{
+  "login": {
+    "title": "Bem-vindo de volta",
+    "subtitle": "Entre na sua conta ShareTab",
+    "email": "E-mail",
+    "emailPlaceholder": "voce@exemplo.com",
+    "password": "Senha",
+    "passwordPlaceholder": "••••••••",
+    "submit": "Entrar",
+    "submitting": "Entrando...",
+    "forgotPassword": "Esqueceu a senha?",
+    "or": "ou",
+    "magicLink": "Entrar com link por e-mail",
+    "magicLinkDescription": "Enviaremos um link mágico para você entrar sem senha. Você pode alterar sua senha nas Configurações após entrar.",
+    "magicLinkEmail": "E-mail",
+    "magicLinkSubmit": "Enviar link mágico",
+    "magicLinkSending": "Enviando...",
+    "magicLinkError": "Não foi possível enviar o link mágico. O e-mail está configurado?",
+    "passwordLink": "Entrar com senha",
+    "noAccount": "Não tem uma conta?",
+    "createAccount": "Criar uma",
+    "quickSplit": "Só precisa dividir uma conta?",
+    "quickSplitLink": "Dividir sem conta",
+    "error": "E-mail ou senha inválidos"
+  },
+  "register": {
+    "title": "Crie sua conta",
+    "subtitle": "Comece a dividir despesas com amigos",
+    "name": "Nome",
+    "namePlaceholder": "Seu nome",
+    "email": "E-mail",
+    "emailPlaceholder": "voce@exemplo.com",
+    "password": "Senha",
+    "passwordPlaceholder": "Pelo menos 8 caracteres",
+    "inviteCode": "Código de convite",
+    "inviteCodePlaceholder": "Digite seu código de convite",
+    "submit": "Criar conta",
+    "submitting": "Criando...",
+    "hasAccount": "Já tem uma conta?",
+    "signIn": "Entrar",
+    "error": {
+      "emailTaken": "Já existe uma conta com este e-mail.",
+      "inviteRequired": "É necessário um código de convite para se registrar.",
+      "inviteInvalid": "Código de convite inválido ou expirado.",
+      "closed": "O registro está fechado no momento.",
+      "generic": "Falha no registro. Tente novamente."
+    }
+  },
+  "verifyRequest": {
+    "title": "Verifique seu e-mail",
+    "description": "Um link de acesso foi enviado para o seu endereço de e-mail.",
+    "instructions": "Clique no link do e-mail para entrar. O link expira em 24 horas.",
+    "spamHint": "Se você não encontrar o e-mail, verifique a pasta de spam.",
+    "backToLogin": "Voltar para o login"
+  },
+  "invite": {
+    "loading": "Carregando...",
+    "title": "Entrar no grupo",
+    "description": "Você foi convidado para participar de um grupo no ShareTab.",
+    "joining": "Entrando...",
+    "accept": "Aceitar convite",
+    "dashboard": "Ir para o Painel"
+  }
+}

--- a/messages/pt-BR/common.json
+++ b/messages/pt-BR/common.json
@@ -1,0 +1,38 @@
+{
+  "nav": {
+    "dashboard": "Painel",
+    "groups": "Grupos",
+    "quickSplit": "Divisão rápida",
+    "settings": "Configurações",
+    "admin": "Admin",
+    "signOut": "Sair",
+    "changeLanguage": "Alterar idioma"
+  },
+  "actions": {
+    "save": "Salvar",
+    "cancel": "Cancelar",
+    "delete": "Excluir",
+    "edit": "Editar",
+    "create": "Criar",
+    "back": "Voltar",
+    "close": "Fechar",
+    "confirm": "Confirmar",
+    "loading": "Carregando...",
+    "saving": "Salvando...",
+    "submit": "Enviar"
+  },
+  "brand": {
+    "name": "ShareTab",
+    "tagline": "Divisão de despesas auto-hospedada com leitura de recibos por IA"
+  },
+  "sponsor": {
+    "title": "Apoie o ShareTab",
+    "description": "O ShareTab é gratuito e de código aberto. Se ele economiza seu tempo, considere patrocinar o desenvolvimento.",
+    "cta": "Patrocinar no GitHub"
+  },
+  "errors": {
+    "generic": "Algo deu errado. Tente novamente.",
+    "notFound": "Não encontrado",
+    "unauthorized": "Você precisa estar conectado para acessar esta página."
+  }
+}

--- a/messages/pt-BR/dashboard.json
+++ b/messages/pt-BR/dashboard.json
@@ -1,0 +1,18 @@
+{
+  "title": "Painel",
+  "youOwe": "Você deve",
+  "youAreOwed": "Devem a você",
+  "owedToYouTitle": "Pessoas que devem a você",
+  "youOweTitle": "Pessoas a quem você deve",
+  "settledUp": "Tudo acertado!",
+  "noGroups": "Nenhum grupo ainda",
+  "noGroupsDescription": "Crie um grupo para começar a dividir despesas.",
+  "createGroup": "Criar grupo",
+  "viewAll": "Ver todos",
+  "recentActivity": "Atividade recente",
+  "noActivity": "Nenhuma atividade recente",
+  "groups": "Grupos",
+  "showMore": "Mostrar mais",
+  "members": "{count, plural, one {# membro} other {# membros}}",
+  "archivedGroups": "{count, plural, one {# grupo arquivado} other {# grupos arquivados}}"
+}

--- a/messages/pt-BR/expenses.json
+++ b/messages/pt-BR/expenses.json
@@ -1,0 +1,46 @@
+{
+  "new": {
+    "title": "Adicionar despesa",
+    "description": "Descrição",
+    "descriptionPlaceholder": "Para que foi isso?",
+    "amount": "Valor",
+    "amountPlaceholder": "0,00",
+    "paidBy": "Pago por",
+    "date": "Data",
+    "splitType": "Tipo de divisão",
+    "splitEqual": "Igual",
+    "splitExact": "Valores exatos",
+    "splitPercentage": "Porcentagem",
+    "splitShares": "Cotas",
+    "submit": "Adicionar despesa",
+    "submitting": "Adicionando..."
+  },
+  "edit": {
+    "title": "Editar despesa",
+    "submit": "Salvar alterações",
+    "submitting": "Salvando..."
+  },
+  "detail": {
+    "paidBy": "Pago por {name}",
+    "addedBy": "Adicionado por {name}",
+    "date": "Data",
+    "split": "Detalhes da divisão",
+    "edit": "Editar",
+    "delete": "Excluir",
+    "deleteConfirm": "Excluir esta despesa?"
+  },
+  "scan": {
+    "title": "Escanear recibo",
+    "upload": "Enviar recibo",
+    "uploadDescription": "Tire uma foto ou envie uma imagem do seu recibo",
+    "processing": "Processando recibo...",
+    "retry": "Tentar novamente"
+  },
+  "splits": {
+    "selectAll": "Selecionar todos",
+    "deselectAll": "Desmarcar todos",
+    "perPerson": "por pessoa",
+    "remaining": "Restante",
+    "total": "Total"
+  }
+}

--- a/messages/pt-BR/groups.json
+++ b/messages/pt-BR/groups.json
@@ -1,0 +1,48 @@
+{
+  "title": "Grupos",
+  "create": "Criar grupo",
+  "new": {
+    "title": "Criar um novo grupo",
+    "name": "Nome do grupo",
+    "namePlaceholder": "ex: Apartamento, Viagem a Paris",
+    "currency": "Moeda",
+    "submit": "Criar grupo",
+    "submitting": "Criando..."
+  },
+  "detail": {
+    "expenses": "Despesas",
+    "balances": "Saldos",
+    "addExpense": "Adicionar despesa",
+    "scanReceipt": "Escanear recibo",
+    "settle": "Acertar contas",
+    "noExpenses": "Nenhuma despesa ainda",
+    "noExpensesDescription": "Adicione uma despesa para começar.",
+    "totalSpent": "Total gasto",
+    "youOwe": "Você deve a {name}",
+    "owesYou": "{name} deve a você",
+    "settledUp": "Acertado"
+  },
+  "settings": {
+    "title": "Configurações do grupo",
+    "name": "Nome do grupo",
+    "currency": "Moeda",
+    "members": "Membros",
+    "addMember": "Adicionar membro",
+    "removeMember": "Remover",
+    "deleteGroup": "Excluir grupo",
+    "deleteConfirm": "Tem certeza? Esta ação não pode ser desfeita.",
+    "invite": "Link de convite",
+    "copyLink": "Copiar link",
+    "linkCopied": "Link copiado!"
+  },
+  "settle": {
+    "title": "Acertar contas",
+    "from": "De",
+    "to": "Para",
+    "amount": "Valor",
+    "submit": "Registrar acerto",
+    "submitting": "Registrando..."
+  },
+  "empty": "Nenhum grupo ainda",
+  "emptyDescription": "Crie seu primeiro grupo para começar a dividir despesas com amigos."
+}

--- a/messages/pt-BR/settings.json
+++ b/messages/pt-BR/settings.json
@@ -1,0 +1,23 @@
+{
+  "title": "Configurações",
+  "profile": {
+    "title": "Perfil",
+    "email": "E-mail",
+    "name": "Nome",
+    "save": "Salvar",
+    "saving": "Salvando...",
+    "saved": "Perfil atualizado!",
+    "language": "Idioma",
+    "languageDescription": "Escolha seu idioma preferido"
+  },
+  "password": {
+    "title": "Alterar senha",
+    "current": "Senha atual",
+    "new": "Nova senha",
+    "confirm": "Confirmar nova senha",
+    "mismatch": "As senhas não coincidem",
+    "submit": "Alterar senha",
+    "submitting": "Alterando...",
+    "success": "Senha alterada!"
+  }
+}

--- a/messages/zh-CN/admin.json
+++ b/messages/zh-CN/admin.json
@@ -1,0 +1,24 @@
+{
+  "title": "管理",
+  "users": {
+    "title": "用户",
+    "total": "用户总数",
+    "active": "活跃",
+    "suspended": "已停用"
+  },
+  "registration": {
+    "title": "注册",
+    "mode": "注册模式",
+    "open": "开放注册",
+    "inviteOnly": "仅限邀请",
+    "closed": "关闭注册"
+  },
+  "activity": {
+    "title": "动态",
+    "noActivity": "暂无最近动态"
+  },
+  "audit": {
+    "title": "审计日志",
+    "noEntries": "暂无审计记录"
+  }
+}

--- a/messages/zh-CN/auth.json
+++ b/messages/zh-CN/auth.json
@@ -1,0 +1,64 @@
+{
+  "login": {
+    "title": "欢迎回来",
+    "subtitle": "登录您的 ShareTab 账户",
+    "email": "电子邮件",
+    "emailPlaceholder": "you@example.com",
+    "password": "密码",
+    "passwordPlaceholder": "••••••••",
+    "submit": "登录",
+    "submitting": "登录中...",
+    "forgotPassword": "忘记密码?",
+    "or": "或",
+    "magicLink": "通过邮件链接登录",
+    "magicLinkDescription": "我们将向您发送一个免密登录链接。登录后可在设置中修改密码。",
+    "magicLinkEmail": "电子邮件",
+    "magicLinkSubmit": "发送登录链接",
+    "magicLinkSending": "发送中...",
+    "magicLinkError": "无法发送登录链接。邮件服务是否已配置?",
+    "passwordLink": "使用密码登录",
+    "noAccount": "还没有账户?",
+    "createAccount": "创建账户",
+    "quickSplit": "只是想分一下账单?",
+    "quickSplitLink": "无需账户直接分账",
+    "error": "邮箱或密码无效"
+  },
+  "register": {
+    "title": "创建您的账户",
+    "subtitle": "开始与朋友分摊费用",
+    "name": "姓名",
+    "namePlaceholder": "您的姓名",
+    "email": "电子邮件",
+    "emailPlaceholder": "you@example.com",
+    "password": "密码",
+    "passwordPlaceholder": "至少8个字符",
+    "inviteCode": "邀请码",
+    "inviteCodePlaceholder": "输入您的邀请码",
+    "submit": "创建账户",
+    "submitting": "创建中...",
+    "hasAccount": "已有账户?",
+    "signIn": "登录",
+    "error": {
+      "emailTaken": "该邮箱已被注册。",
+      "inviteRequired": "注册需要邀请码。",
+      "inviteInvalid": "邀请码无效或已过期。",
+      "closed": "注册目前已关闭。",
+      "generic": "注册失败，请重试。"
+    }
+  },
+  "verifyRequest": {
+    "title": "请查看您的邮箱",
+    "description": "登录链接已发送至您的邮箱。",
+    "instructions": "点击邮件中的链接即可登录。链接将在24小时后过期。",
+    "spamHint": "如果未收到邮件，请检查垃圾邮件文件夹。",
+    "backToLogin": "返回登录"
+  },
+  "invite": {
+    "loading": "加载中...",
+    "title": "加入群组",
+    "description": "您已被邀请加入 ShareTab 上的一个群组。",
+    "joining": "加入中...",
+    "accept": "接受邀请",
+    "dashboard": "前往仪表盘"
+  }
+}

--- a/messages/zh-CN/common.json
+++ b/messages/zh-CN/common.json
@@ -1,0 +1,38 @@
+{
+  "nav": {
+    "dashboard": "仪表盘",
+    "groups": "群组",
+    "quickSplit": "快速分账",
+    "settings": "设置",
+    "admin": "管理",
+    "signOut": "退出登录",
+    "changeLanguage": "切换语言"
+  },
+  "actions": {
+    "save": "保存",
+    "cancel": "取消",
+    "delete": "删除",
+    "edit": "编辑",
+    "create": "创建",
+    "back": "返回",
+    "close": "关闭",
+    "confirm": "确认",
+    "loading": "加载中...",
+    "saving": "保存中...",
+    "submit": "提交"
+  },
+  "brand": {
+    "name": "ShareTab",
+    "tagline": "自托管的费用分摊工具，支持 AI 小票扫描"
+  },
+  "sponsor": {
+    "title": "支持 ShareTab",
+    "description": "ShareTab 是免费开源项目。如果它帮你节省了时间，请考虑赞助开发。",
+    "cta": "在 GitHub 上赞助"
+  },
+  "errors": {
+    "generic": "出了点问题，请重试。",
+    "notFound": "未找到",
+    "unauthorized": "请先登录再访问此页面。"
+  }
+}

--- a/messages/zh-CN/dashboard.json
+++ b/messages/zh-CN/dashboard.json
@@ -1,0 +1,18 @@
+{
+  "title": "仪表盘",
+  "youOwe": "你欠",
+  "youAreOwed": "别人欠你",
+  "owedToYouTitle": "欠你钱的人",
+  "youOweTitle": "你欠钱的人",
+  "settledUp": "已全部结清!",
+  "noGroups": "暂无群组",
+  "noGroupsDescription": "创建一个群组来开始分摊费用。",
+  "createGroup": "创建群组",
+  "viewAll": "查看全部",
+  "recentActivity": "最近动态",
+  "noActivity": "暂无最近动态",
+  "groups": "群组",
+  "showMore": "显示更多",
+  "members": "{count, plural, other {#位成员}}",
+  "archivedGroups": "{count, plural, other {#个已归档群组}}"
+}

--- a/messages/zh-CN/expenses.json
+++ b/messages/zh-CN/expenses.json
@@ -1,0 +1,46 @@
+{
+  "new": {
+    "title": "添加费用",
+    "description": "描述",
+    "descriptionPlaceholder": "这笔费用是什么?",
+    "amount": "金额",
+    "amountPlaceholder": "0.00",
+    "paidBy": "付款人",
+    "date": "日期",
+    "splitType": "分摊方式",
+    "splitEqual": "平均分摊",
+    "splitExact": "按金额",
+    "splitPercentage": "按百分比",
+    "splitShares": "按份额",
+    "submit": "添加费用",
+    "submitting": "添加中..."
+  },
+  "edit": {
+    "title": "编辑费用",
+    "submit": "保存更改",
+    "submitting": "保存中..."
+  },
+  "detail": {
+    "paidBy": "{name}支付",
+    "addedBy": "{name}添加",
+    "date": "日期",
+    "split": "分摊详情",
+    "edit": "编辑",
+    "delete": "删除",
+    "deleteConfirm": "确定删除这笔费用?"
+  },
+  "scan": {
+    "title": "扫描小票",
+    "upload": "上传小票",
+    "uploadDescription": "拍照或上传小票图片",
+    "processing": "正在处理小票...",
+    "retry": "重试"
+  },
+  "splits": {
+    "selectAll": "全选",
+    "deselectAll": "取消全选",
+    "perPerson": "每人",
+    "remaining": "剩余",
+    "total": "合计"
+  }
+}

--- a/messages/zh-CN/groups.json
+++ b/messages/zh-CN/groups.json
@@ -1,0 +1,48 @@
+{
+  "title": "群组",
+  "create": "创建群组",
+  "new": {
+    "title": "创建新群组",
+    "name": "群组名称",
+    "namePlaceholder": "例如：合租、巴黎旅行",
+    "currency": "货币",
+    "submit": "创建群组",
+    "submitting": "创建中..."
+  },
+  "detail": {
+    "expenses": "费用",
+    "balances": "余额",
+    "addExpense": "添加费用",
+    "scanReceipt": "扫描小票",
+    "settle": "结算",
+    "noExpenses": "暂无费用",
+    "noExpensesDescription": "添加一笔费用来开始使用。",
+    "totalSpent": "总支出",
+    "youOwe": "你欠{name}",
+    "owesYou": "{name}欠你",
+    "settledUp": "已结清"
+  },
+  "settings": {
+    "title": "群组设置",
+    "name": "群组名称",
+    "currency": "货币",
+    "members": "成员",
+    "addMember": "添加成员",
+    "removeMember": "移除",
+    "deleteGroup": "删除群组",
+    "deleteConfirm": "确定要删除吗？此操作无法撤销。",
+    "invite": "邀请链接",
+    "copyLink": "复制链接",
+    "linkCopied": "链接已复制!"
+  },
+  "settle": {
+    "title": "结算",
+    "from": "付款人",
+    "to": "收款人",
+    "amount": "金额",
+    "submit": "记录结算",
+    "submitting": "记录中..."
+  },
+  "empty": "暂无群组",
+  "emptyDescription": "创建您的第一个群组，开始与朋友分摊费用。"
+}

--- a/messages/zh-CN/settings.json
+++ b/messages/zh-CN/settings.json
@@ -1,0 +1,23 @@
+{
+  "title": "设置",
+  "profile": {
+    "title": "个人资料",
+    "email": "电子邮件",
+    "name": "姓名",
+    "save": "保存",
+    "saving": "保存中...",
+    "saved": "资料已更新!",
+    "language": "语言",
+    "languageDescription": "选择您的首选语言"
+  },
+  "password": {
+    "title": "修改密码",
+    "current": "当前密码",
+    "new": "新密码",
+    "confirm": "确认新密码",
+    "mismatch": "两次输入的密码不一致",
+    "submit": "修改密码",
+    "submitting": "修改中...",
+    "success": "密码已修改!"
+  }
+}

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -1,6 +1,6 @@
 import { defineRouting } from "next-intl/routing";
 
-export const locales = ["en", "es"] as const;
+export const locales = ["en", "es", "fr", "de", "pt-BR", "ja", "zh-CN", "ko"] as const;
 export type Locale = (typeof locales)[number];
 export const defaultLocale: Locale = "en";
 
@@ -9,6 +9,12 @@ export const rtlLocales: Locale[] = [];
 export const languageConfig: Record<Locale, { flag: string; name: string }> = {
   en: { flag: "\u{1F1FA}\u{1F1F8}", name: "English" },
   es: { flag: "\u{1F1EA}\u{1F1F8}", name: "Espa\u00F1ol" },
+  fr: { flag: "\u{1F1EB}\u{1F1F7}", name: "Fran\u00E7ais" },
+  de: { flag: "\u{1F1E9}\u{1F1EA}", name: "Deutsch" },
+  "pt-BR": { flag: "\u{1F1E7}\u{1F1F7}", name: "Portugu\u00EAs" },
+  ja: { flag: "\u{1F1EF}\u{1F1F5}", name: "\u65E5\u672C\u8A9E" },
+  "zh-CN": { flag: "\u{1F1E8}\u{1F1F3}", name: "\u4E2D\u6587" },
+  ko: { flag: "\u{1F1F0}\u{1F1F7}", name: "\uD55C\uAD6D\uC5B4" },
 };
 
 export const routing = defineRouting({

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -11,9 +11,9 @@ export const languageConfig: Record<Locale, { flag: string; name: string }> = {
   es: { flag: "\u{1F1EA}\u{1F1F8}", name: "Espa\u00F1ol" },
   fr: { flag: "\u{1F1EB}\u{1F1F7}", name: "Fran\u00E7ais" },
   de: { flag: "\u{1F1E9}\u{1F1EA}", name: "Deutsch" },
-  "pt-BR": { flag: "\u{1F1E7}\u{1F1F7}", name: "Portugu\u00EAs" },
+  "pt-BR": { flag: "\u{1F1E7}\u{1F1F7}", name: "Portugu\u00EAs (Brasil)" },
   ja: { flag: "\u{1F1EF}\u{1F1F5}", name: "\u65E5\u672C\u8A9E" },
-  "zh-CN": { flag: "\u{1F1E8}\u{1F1F3}", name: "\u4E2D\u6587" },
+  "zh-CN": { flag: "\u{1F1E8}\u{1F1F3}", name: "\u4E2D\u6587 (\u7B80\u4F53)" },
   ko: { flag: "\u{1F1F0}\u{1F1F7}", name: "\uD55C\uAD6D\uC5B4" },
 };
 


### PR DESCRIPTION
## Summary
- Add complete translations for **French, German, Brazilian Portuguese, Japanese, Simplified Chinese, and Korean** (42 new JSON files, 197 keys each)
- Register all 6 new locales in `src/i18n/routing.ts` with native names and country flags
- All translations verified against standard web localization conventions via web search
- Key parity validated: all 8 locales have identical key structure across 7 namespaces

## Languages Added
| Locale | Language | Flag |
|--------|----------|------|
| fr | Français | 🇫🇷 |
| de | Deutsch | 🇩🇪 |
| pt-BR | Português (Brasil) | 🇧🇷 |
| ja | 日本語 | 🇯🇵 |
| zh-CN | 中文 (简体) | 🇨🇳 |
| ko | 한국어 | 🇰🇷 |

## Translation Quality
- **European languages**: Standard idiomatic terms verified (FR: "Tableau de bord", "Paramètres"; DE: "Übersicht", "Einstellungen"; pt-BR: "Configurações", "Salvar")
- **Asian languages**: Correct character sets (Simplified Chinese, not Traditional), standard katakana loanwords for JA, standard Hangul terms for KO
- **ICU plurals**: FR/DE/pt-BR use `one`+`other` branches; JA/zh-CN/KO correctly use `other`-only (no grammatical plural)
- **Diacriticals**: Verified present in FR (é, è, ç, à) and pt-BR (ã, ç, é, ê, ó)

## Test plan
- [ ] `npm run lint:i18n` passes (key parity check)
- [ ] Language switcher shows all 8 languages
- [ ] Switching to each language renders translated strings (not English)
- [ ] ICU plural strings render correctly (e.g., "1 member" / "2 members" equivalent)
- [ ] Diacritical marks display correctly in FR and pt-BR
- [ ] CJK characters render correctly in JA, zh-CN, KO