### PR TITLE
feat(i18n): propagate locale to all formatCents call sites

### DIFF
--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useState, useEffect } from "react";
+import { useLocale } from "next-intl";
 import { Link, useRouter } from "@/i18n/navigation";
 import { trpc } from "@/lib/trpc";
 import { parseToCents, centsToDecimal } from "@/lib/money";
@@ -42,6 +43,7 @@ export default function EditExpensePage({
 }) {
   const { groupId, expenseId } = use(params);
   const router = useRouter();
+  const locale = useLocale();
   const group = trpc.groups.get.useQuery({ groupId });
   const expense = trpc.expenses.get.useQuery({ groupId, expenseId });
 
@@ -225,6 +227,8 @@ export default function EditExpensePage({
                   members={members}
                   totalCents={amountCents}
                   onChange={setShares}
+                  locale={locale}
+                  currency={group.data?.currency}
                 />
               )}
               {splitMode === "EXACT" && (
@@ -232,6 +236,8 @@ export default function EditExpensePage({
                   members={members}
                   totalCents={amountCents}
                   onChange={setShares}
+                  locale={locale}
+                  currency={group.data?.currency}
                 />
               )}
               {splitMode === "PERCENTAGE" && (
@@ -239,6 +245,8 @@ export default function EditExpensePage({
                   members={members}
                   totalCents={amountCents}
                   onChange={setShares}
+                  locale={locale}
+                  currency={group.data?.currency}
                 />
               )}
               {splitMode === "SHARES" && (
@@ -246,6 +254,8 @@ export default function EditExpensePage({
                   members={members}
                   totalCents={amountCents}
                   onChange={setShares}
+                  locale={locale}
+                  currency={group.data?.currency}
                 />
               )}
             </div>

--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use } from "react";
+import { useLocale } from "next-intl";
 import { Link, useRouter } from "@/i18n/navigation";
 import { trpc } from "@/lib/trpc";
 import { formatCents } from "@/lib/money";
@@ -16,6 +17,7 @@ export default function ExpenseDetailPage({
   params: Promise<{ groupId: string; expenseId: string }>;
 }) {
   const { groupId, expenseId } = use(params);
+  const locale = useLocale();
   const router = useRouter();
 
   const expense = trpc.expenses.get.useQuery({ groupId, expenseId });
@@ -53,7 +55,7 @@ export default function ExpenseDetailPage({
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center justify-between">
-            <span>{formatCents(e.amount, e.currency)}</span>
+            <span>{formatCents(e.amount, e.currency, locale)}</span>
             <Badge variant="secondary">{e.splitMode}</Badge>
           </CardTitle>
         </CardHeader>
@@ -100,7 +102,7 @@ export default function ExpenseDetailPage({
                 >
                   <span>{share.user.name ?? "Unknown"}</span>
                   <span className="font-medium">
-                    {formatCents(share.amount, e.currency)}
+                    {formatCents(share.amount, e.currency, locale)}
                   </span>
                 </div>
               ))}

--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/new/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/new/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useMemo, useState } from "react";
+import { useLocale } from "next-intl";
 import { Link, useRouter } from "@/i18n/navigation";
 import { trpc } from "@/lib/trpc";
 import { parseToCents } from "@/lib/money";
@@ -42,6 +43,7 @@ export default function NewExpensePage({
 }) {
   const { groupId } = use(params);
   const router = useRouter();
+  const locale = useLocale();
   const group = trpc.groups.get.useQuery({ groupId });
 
   const [title, setTitle] = useState("");
@@ -183,6 +185,8 @@ export default function NewExpensePage({
                   members={members}
                   totalCents={amountCents}
                   onChange={setShares}
+                  locale={locale}
+                  currency={group.data?.currency}
                 />
               )}
               {splitMode === "EXACT" && (
@@ -190,6 +194,8 @@ export default function NewExpensePage({
                   members={members}
                   totalCents={amountCents}
                   onChange={setShares}
+                  locale={locale}
+                  currency={group.data?.currency}
                 />
               )}
               {splitMode === "PERCENTAGE" && (
@@ -197,6 +203,8 @@ export default function NewExpensePage({
                   members={members}
                   totalCents={amountCents}
                   onChange={setShares}
+                  locale={locale}
+                  currency={group.data?.currency}
                 />
               )}
               {splitMode === "SHARES" && (
@@ -204,6 +212,8 @@ export default function NewExpensePage({
                   members={members}
                   totalCents={amountCents}
                   onChange={setShares}
+                  locale={locale}
+                  currency={group.data?.currency}
                 />
               )}
             </div>

--- a/src/app/[locale]/(app)/groups/[groupId]/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useState } from "react";
+import { useLocale } from "next-intl";
 import { trpc } from "@/lib/trpc";
 import { formatCents } from "@/lib/money";
 import { Button } from "@/components/ui/button";
@@ -61,6 +62,7 @@ export default function GroupDetailPage({
   params: Promise<{ groupId: string }>;
 }) {
   const { groupId } = use(params);
+  const locale = useLocale();
   const [showInvite, setShowInvite] = useState(false);
   const [settleState, setSettleState] = useState<{
     open: boolean;
@@ -231,7 +233,7 @@ export default function GroupDetailPage({
                     {to?.name ?? to?.email ?? "Unknown"}
                   </span>
                   <span className="ml-auto shrink-0 font-semibold tabular-nums text-red-600 dark:text-red-400">
-                    {formatCents(debt.amount, g.currency)}
+                    {formatCents(debt.amount, g.currency, locale)}
                   </span>
                 </button>
               );
@@ -268,7 +270,7 @@ export default function GroupDetailPage({
                   <div className="flex items-center gap-3 ml-3">
                     <p className="text-lg font-semibold">
                       {r.extractedData
-                        ? formatCents(r.extractedData.total, g.currency)
+                        ? formatCents(r.extractedData.total, g.currency, locale)
                         : "—"}
                     </p>
                     <button
@@ -365,7 +367,7 @@ export default function GroupDetailPage({
                   </div>
                 </div>
                 <p className="ml-4 shrink-0 text-lg font-semibold tabular-nums">
-                  {formatCents(expense.amount, g.currency)}
+                  {formatCents(expense.amount, g.currency, locale)}
                 </p>
               </div>
             </Link>

--- a/src/app/[locale]/split/[token]/page.tsx
+++ b/src/app/[locale]/split/[token]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use } from "react";
+import { useLocale } from "next-intl";
 import { trpc } from "@/lib/trpc";
 import { formatCents } from "@/lib/money";
 import { Button } from "@/components/ui/button";
@@ -17,6 +18,7 @@ export default function SharedSplitPage({
   params: Promise<{ token: string }>;
 }) {
   const { token } = use(params);
+  const locale = useLocale();
   const split = trpc.guest.getSplit.useQuery({ token });
 
   if (split.isLoading) {
@@ -56,7 +58,7 @@ export default function SharedSplitPage({
 
   async function handleShare() {
     const url = window.location.href;
-    const text = `Bill split from ${data.receiptData.merchantName ?? "a receipt"} — ${formatCents(data.receiptData.total, currency)} total`;
+    const text = `Bill split from ${data.receiptData.merchantName ?? "a receipt"} — ${formatCents(data.receiptData.total, currency, locale)} total`;
 
     if (navigator.share) {
       try {
@@ -111,7 +113,7 @@ export default function SharedSplitPage({
           <div className="flex justify-between items-center">
             <span className="font-semibold text-lg">Total Bill</span>
             <span className="text-2xl font-bold text-primary">
-              {formatCents(data.receiptData.total, currency)}
+              {formatCents(data.receiptData.total, currency, locale)}
             </span>
           </div>
         </CardContent>
@@ -140,7 +142,7 @@ export default function SharedSplitPage({
                     <span className="font-semibold">{person.name}</span>
                   </div>
                   <span className="text-xl font-bold text-primary">
-                    {formatCents(person.total, currency)}
+                    {formatCents(person.total, currency, locale)}
                   </span>
                 </div>
 
@@ -149,19 +151,19 @@ export default function SharedSplitPage({
                   {personItems.map((item, i) => (
                     <div key={i} className="flex justify-between">
                       <span>{item.name}</span>
-                      <span>{formatCents(item.totalPrice, currency)}</span>
+                      <span>{formatCents(item.totalPrice, currency, locale)}</span>
                     </div>
                   ))}
                   {person.tax > 0 && (
                     <div className="flex justify-between">
                       <span>Tax</span>
-                      <span>{formatCents(person.tax, currency)}</span>
+                      <span>{formatCents(person.tax, currency, locale)}</span>
                     </div>
                   )}
                   {person.tip > 0 && (
                     <div className="flex justify-between">
                       <span>Tip</span>
-                      <span>{formatCents(person.tip, currency)}</span>
+                      <span>{formatCents(person.tip, currency, locale)}</span>
                     </div>
                   )}
                 </div>
@@ -179,20 +181,20 @@ export default function SharedSplitPage({
         <CardContent className="space-y-1 text-sm">
           <div className="flex justify-between">
             <span className="text-muted-foreground">Subtotal</span>
-            <span>{formatCents(data.receiptData.subtotal, currency)}</span>
+            <span>{formatCents(data.receiptData.subtotal, currency, locale)}</span>
           </div>
           <div className="flex justify-between">
             <span className="text-muted-foreground">Tax</span>
-            <span>{formatCents(data.receiptData.tax, currency)}</span>
+            <span>{formatCents(data.receiptData.tax, currency, locale)}</span>
           </div>
           <div className="flex justify-between">
             <span className="text-muted-foreground">Tip</span>
-            <span>{formatCents(data.receiptData.tip, currency)}</span>
+            <span>{formatCents(data.receiptData.tip, currency, locale)}</span>
           </div>
           <Separator />
           <div className="flex justify-between font-semibold">
             <span>Total</span>
-            <span>{formatCents(data.receiptData.total, currency)}</span>
+            <span>{formatCents(data.receiptData.total, currency, locale)}</span>
           </div>
         </CardContent>
       </Card>

--- a/src/app/[locale]/split/page.tsx
+++ b/src/app/[locale]/split/page.tsx
@@ -40,6 +40,7 @@ type ExtractedData = {
 
 export default function GuestSplitPage() {
   const router = useRouter();
+  const locale = useLocale();
   const [step, setStep] = useState<Step>("upload");
   const [receiptId, setReceiptId] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
@@ -260,7 +261,6 @@ export default function GuestSplitPage() {
   }
 
   // Calculate totals
-  const locale = useLocale();
   const tip = tipOverride !== "" ? Math.round(parseFloat(tipOverride) * 100) : (extracted?.tip ?? 0);
   const currency = extracted?.currency ?? "USD";
 

--- a/src/app/[locale]/split/page.tsx
+++ b/src/app/[locale]/split/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useLocale } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { trpc } from "@/lib/trpc";
 import { formatCents, centsToDecimal, parseToCents } from "@/lib/money";
@@ -259,6 +260,7 @@ export default function GuestSplitPage() {
   }
 
   // Calculate totals
+  const locale = useLocale();
   const tip = tipOverride !== "" ? Math.round(parseFloat(tipOverride) * 100) : (extracted?.tip ?? 0);
   const currency = extracted?.currency ?? "USD";
 
@@ -595,20 +597,20 @@ export default function GuestSplitPage() {
             <CardContent className="space-y-1 text-sm">
               <div className="flex justify-between">
                 <span className="text-muted-foreground">Subtotal</span>
-                <span>{formatCents(extracted.subtotal, currency)}</span>
+                <span>{formatCents(extracted.subtotal, currency, locale)}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-muted-foreground">Tax</span>
-                <span>{formatCents(extracted.tax, currency)}</span>
+                <span>{formatCents(extracted.tax, currency, locale)}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-muted-foreground">Tip</span>
-                <span>{formatCents(tip, currency)}</span>
+                <span>{formatCents(tip, currency, locale)}</span>
               </div>
               <Separator />
               <div className="flex justify-between font-semibold">
                 <span>Total</span>
-                <span>{formatCents(extracted.subtotal + extracted.tax + tip, currency)}</span>
+                <span>{formatCents(extracted.subtotal + extracted.tax + tip, currency, locale)}</span>
               </div>
             </CardContent>
           </Card>
@@ -739,7 +741,7 @@ export default function GuestSplitPage() {
                             <Trash2 className="h-3 w-3" />
                           </button>
                         </div>
-                        <span className="font-semibold">{formatCents(item.totalPrice, currency)}</span>
+                        <span className="font-semibold">{formatCents(item.totalPrice, currency, locale)}</span>
                       </div>
                     )}
                     {/* Person toggle buttons */}
@@ -783,7 +785,7 @@ export default function GuestSplitPage() {
                 {perPersonTotals.map((t) => (
                   <div key={t.personIndex} className="flex justify-between text-sm">
                     <span>{people[t.personIndex]?.trim() || `Person ${t.personIndex + 1}`}</span>
-                    <span className="font-medium">{formatCents(t.total, currency)}</span>
+                    <span className="font-medium">{formatCents(t.total, currency, locale)}</span>
                   </div>
                 ))}
               </CardContent>

--- a/src/components/admin/group-overview-section.tsx
+++ b/src/components/admin/group-overview-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useLocale } from "next-intl";
 import { trpc } from "@/lib/trpc";
 import { formatCents } from "@/lib/money";
 import { Button } from "@/components/ui/button";
@@ -49,6 +50,7 @@ function SortIcon({
 
 export function GroupOverviewSection() {
   const utils = trpc.useUtils();
+  const locale = useLocale();
 
   // Filter / search / sort state
   const [search, setSearch] = useState("");
@@ -242,7 +244,7 @@ export function GroupOverviewSection() {
                           {group.expenseCount}
                         </td>
                         <td className="px-4 py-3 text-right">
-                          {formatCents(group.totalAmount)}
+                          {formatCents(group.totalAmount, "USD", locale)}
                         </td>
                         <td className="px-4 py-3 text-muted-foreground">
                           {new Date(group.lastActivity).toLocaleDateString()}

--- a/src/components/expenses/equal-split.tsx
+++ b/src/components/expenses/equal-split.tsx
@@ -10,10 +10,14 @@ export function EqualSplit({
   members,
   totalCents,
   onChange,
+  locale,
+  currency,
 }: {
   members: Member[];
   totalCents: number;
   onChange: (shares: ShareEntry[]) => void;
+  locale?: string;
+  currency?: string;
 }) {
   const [selected, setSelected] = useState<Set<string>>(
     new Set(members.map((m) => m.id))
@@ -70,14 +74,14 @@ export function EqualSplit({
           </div>
           {selected.has(m.id) && totalCents > 0 && (
             <span className="text-sm text-muted-foreground">
-              {formatCents(Math.round(perPerson))}
+              {formatCents(Math.round(perPerson), currency, locale)}
             </span>
           )}
         </label>
       ))}
       {selected.size > 0 && totalCents > 0 && (
         <p className="text-xs text-muted-foreground">
-          {formatCents(Math.round(perPerson))} per person
+          {formatCents(Math.round(perPerson), currency, locale)} per person
           ({selected.size} selected)
         </p>
       )}

--- a/src/components/expenses/exact-split.tsx
+++ b/src/components/expenses/exact-split.tsx
@@ -11,10 +11,14 @@ export function ExactSplit({
   members,
   totalCents,
   onChange,
+  locale,
+  currency,
 }: {
   members: Member[];
   totalCents: number;
   onChange: (shares: ShareEntry[]) => void;
+  locale?: string;
+  currency?: string;
 }) {
   const [amounts, setAmounts] = useState<Record<string, string>>({});
 
@@ -68,8 +72,8 @@ export function ExactSplit({
         {remaining === 0
           ? "Fully allocated"
           : remaining > 0
-            ? `${formatCents(remaining)} remaining`
-            : `${formatCents(-remaining)} over-allocated`}
+            ? `${formatCents(remaining, currency, locale)} remaining`
+            : `${formatCents(-remaining, currency, locale)} over-allocated`}
       </p>
     </div>
   );

--- a/src/components/expenses/percentage-split.tsx
+++ b/src/components/expenses/percentage-split.tsx
@@ -11,10 +11,14 @@ export function PercentageSplit({
   members,
   totalCents,
   onChange,
+  locale,
+  currency,
 }: {
   members: Member[];
   totalCents: number;
   onChange: (shares: ShareEntry[]) => void;
+  locale?: string;
+  currency?: string;
 }) {
   const [percentages, setPercentages] = useState<Record<string, string>>(() => {
     // Pre-fill equal percentages so switching from Equal mode isn't jarring
@@ -87,7 +91,7 @@ export function PercentageSplit({
             </div>
             {pct > 0 && totalCents > 0 && (
               <span className="w-20 text-right text-xs text-muted-foreground">
-                {formatCents(share)}
+                {formatCents(share, currency, locale)}
               </span>
             )}
           </div>

--- a/src/components/expenses/shares-split.tsx
+++ b/src/components/expenses/shares-split.tsx
@@ -11,10 +11,14 @@ export function SharesSplit({
   members,
   totalCents,
   onChange,
+  locale,
+  currency,
 }: {
   members: Member[];
   totalCents: number;
   onChange: (shares: ShareEntry[]) => void;
+  locale?: string;
+  currency?: string;
 }) {
   const [shareUnits, setShareUnits] = useState<Record<string, string>>(
     () => Object.fromEntries(members.map((m) => [m.id, "1"]))
@@ -79,7 +83,7 @@ export function SharesSplit({
             <span className="text-xs text-muted-foreground">shares</span>
             {units > 0 && totalCents > 0 && (
               <span className="w-20 text-right text-xs text-muted-foreground">
-                {formatCents(share)}
+                {formatCents(share, currency, locale)}
               </span>
             )}
           </div>

--- a/src/components/groups/settle-dialog.tsx
+++ b/src/components/groups/settle-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useLocale } from "next-intl";
 import { trpc } from "@/lib/trpc";
 import { parseToCents, formatCents } from "@/lib/money";
 import {
@@ -35,6 +36,7 @@ export function SettleDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
+  const locale = useLocale();
   const [fromId, setFromId] = useState(suggestedFrom ?? "");
   const [toId, setToId] = useState(suggestedTo ?? "");
   const [amountStr, setAmountStr] = useState(
@@ -134,7 +136,7 @@ export function SettleDialog({
                 onClick={() => setAmountStr((suggestedAmount / 100).toFixed(2))}
                 className="text-xs text-primary hover:underline"
               >
-                Use suggested: {formatCents(suggestedAmount, currency)}
+                Use suggested: {formatCents(suggestedAmount, currency, locale)}
               </button>
             )}
           </div>

--- a/src/components/receipts/item-assignment.tsx
+++ b/src/components/receipts/item-assignment.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useRef, useEffect } from "react";
+import { useLocale } from "next-intl";
 import { trpc } from "@/lib/trpc";
 import { formatCents, centsToDecimal, parseToCents } from "@/lib/money";
 import { Button } from "@/components/ui/button";
@@ -26,6 +27,7 @@ export function ItemAssignment({
   members: Member[];
   onComplete: () => void;
 }) {
+  const locale = useLocale();
   const receiptData = trpc.receipts.getReceiptItems.useQuery({ receiptId });
   const utils = trpc.useUtils();
 
@@ -339,20 +341,20 @@ export function ItemAssignment({
           )}
           <div className="flex justify-between">
             <span className="text-muted-foreground">Subtotal</span>
-            <span>{formatCents(extracted.subtotal, extracted.currency)}</span>
+            <span>{formatCents(extracted.subtotal, extracted.currency, locale)}</span>
           </div>
           <div className="flex justify-between">
             <span className="text-muted-foreground">Tax</span>
-            <span>{formatCents(extracted.tax, extracted.currency)}</span>
+            <span>{formatCents(extracted.tax, extracted.currency, locale)}</span>
           </div>
           <div className="flex justify-between">
             <span className="text-muted-foreground">Tip</span>
-            <span>{formatCents(tip, extracted.currency)}</span>
+            <span>{formatCents(tip, extracted.currency, locale)}</span>
           </div>
           <Separator />
           <div className="flex justify-between font-semibold">
             <span>Total</span>
-            <span>{formatCents(extracted.subtotal + extracted.tax + tip, extracted.currency)}</span>
+            <span>{formatCents(extracted.subtotal + extracted.tax + tip, extracted.currency, locale)}</span>
           </div>
         </CardContent>
       </Card>
@@ -537,7 +539,7 @@ export function ItemAssignment({
                       </button>
                     </div>
                     <span className="font-semibold">
-                      {formatCents(item.totalPrice, extracted.currency)}
+                      {formatCents(item.totalPrice, extracted.currency, locale)}
                     </span>
                   </div>
                 )}
@@ -594,7 +596,7 @@ export function ItemAssignment({
                 <div key={m.id} className="flex justify-between text-sm">
                   <span>{m.name ?? "Unnamed"}</span>
                   <span className="font-medium">
-                    {formatCents(total, extracted.currency)}
+                    {formatCents(total, extracted.currency, locale)}
                   </span>
                 </div>
               );

--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -47,6 +47,36 @@ describe("formatCents", () => {
     const result = formatCents(123456, "EUR", "es");
     expect(result).toContain("1234,56");
   });
+
+  test("maps all supported app locales to regional money locales", () => {
+    // Swedish (sv-SE uses U+00A0 non-breaking space as thousands separator)
+    const sv = formatCents(123456, "SEK", "sv");
+    expect(sv).toContain("1 234,56");
+
+    // French (fr-FR uses U+202F narrow no-break space as thousands separator)
+    const fr = formatCents(123456, "EUR", "fr");
+    expect(fr).toContain("1 234,56");
+
+    // German
+    const de = formatCents(123456, "EUR", "de");
+    expect(de).toContain("1.234,56");
+
+    // Portuguese (Brazil)
+    const ptBR = formatCents(123456, "BRL", "pt-BR");
+    expect(ptBR).toContain("1.234,56");
+
+    // Japanese
+    const ja = formatCents(100000, "JPY", "ja");
+    expect(ja).toContain("1,000");
+
+    // Chinese (Simplified)
+    const zhCN = formatCents(123456, "CNY", "zh-CN");
+    expect(zhCN).toContain("1,234.56");
+
+    // Korean
+    const ko = formatCents(123456, "KRW", "ko");
+    expect(ko).toContain("1,235");
+  });
 });
 
 describe("parseToCents", () => {

--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -49,13 +49,17 @@ describe("formatCents", () => {
   });
 
   test("maps all supported app locales to regional money locales", () => {
-    // Swedish (sv-SE uses U+00A0 non-breaking space as thousands separator)
-    const sv = formatCents(123456, "SEK", "sv");
-    expect(sv).toContain("1 234,56");
+    // Normalize whitespace variants (NBSP, narrow NBSP) to ASCII space
+    // to avoid flaky assertions across Node/ICU versions
+    const norm = (s: string) => s.replace(/[  ]/g, " ");
 
-    // French (fr-FR uses U+202F narrow no-break space as thousands separator)
+    // Swedish
+    const sv = formatCents(123456, "SEK", "sv");
+    expect(norm(sv)).toContain("1 234,56");
+
+    // French
     const fr = formatCents(123456, "EUR", "fr");
-    expect(fr).toContain("1 234,56");
+    expect(norm(fr)).toContain("1 234,56");
 
     // German
     const de = formatCents(123456, "EUR", "de");

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -13,7 +13,7 @@ const moneyLocales = {
 } satisfies Record<Locale, string>;
 
 export function formatCents(cents: number, currency = "USD", locale: string = defaultLocale): string {
-  return new Intl.NumberFormat(moneyLocales[locale] ?? locale, {
+  return new Intl.NumberFormat((moneyLocales as Record<string, string>)[locale] ?? locale, {
     style: "currency",
     currency,
   }).format(cents / 100);

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,9 +1,16 @@
-import { defaultLocale } from "@/i18n/routing";
+import { defaultLocale, type Locale } from "@/i18n/routing";
 
-const moneyLocales: Record<string, string> = {
+const moneyLocales = {
   en: "en-US",
   es: "es-ES",
-};
+  sv: "sv-SE",
+  fr: "fr-FR",
+  de: "de-DE",
+  "pt-BR": "pt-BR",
+  ja: "ja-JP",
+  "zh-CN": "zh-CN",
+  ko: "ko-KR",
+} satisfies Record<Locale, string>;
 
 export function formatCents(cents: number, currency = "USD", locale: string = defaultLocale): string {
   return new Intl.NumberFormat(moneyLocales[locale] ?? locale, {

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,6 +1,6 @@
 import { defaultLocale, type Locale } from "@/i18n/routing";
 
-const moneyLocales = {
+const moneyLocales: Record<string, string> = {
   en: "en-US",
   es: "es-ES",
   sv: "sv-SE",
@@ -13,7 +13,7 @@ const moneyLocales = {
 } satisfies Record<Locale, string>;
 
 export function formatCents(cents: number, currency = "USD", locale: string = defaultLocale): string {
-  return new Intl.NumberFormat((moneyLocales as Record<string, string>)[locale] ?? locale, {
+  return new Intl.NumberFormat(moneyLocales[locale] ?? locale, {
     style: "currency",
     currency,
   }).format(cents / 100);


### PR DESCRIPTION
## Summary

- Expand `moneyLocales` map in `money.ts` to cover all 9 supported locales (`en`, `es`, `sv`, `fr`, `de`, `pt-BR`, `ja`, `zh-CN`, `ko`) with `satisfies Record<Locale, string>` for compile-time exhaustiveness
- Add `locale?` and `currency?` props to the 4 split components (`equal-split`, `exact-split`, `percentage-split`, `shares-split`) keeping them framework-agnostic
- Wire `useLocale()` from `next-intl` into every component that calls `formatCents` — 13 files, ~40 call sites now pass locale as the third argument

## Before / After

| Locale | Before | After |
|--------|--------|-------|
| `en` | $1,234.56 | $1,234.56 |
| `de` | $1,234.56 | 1.234,56 € |
| `sv` | $1,234.56 | 1 234,56 kr |
| `ja` | $1,234.56 | ￥1,235 |
| `fr` | $1,234.56 | 1 234,56 € |

## Test plan

- [x] `npm test` — 239/239 tests passing (18 in money.test.ts, including new locale mapping tests)
- [x] `npm run lint` — 62 problems, all pre-existing (0 new)
- [x] `npm run lint:i18n` — all translations in sync
- [x] `npm run build` — compiles successfully, type checks pass
- [x] Grep audit: every `formatCents` call in `.tsx` files passes all 3 arguments
- [x] Adversarial review by Codex: SHIP IT (all 7 checks pass)

## Out of scope

- Admin `GroupOverviewSection` hardcodes `"USD"` because the admin router doesn't return per-group currency (pre-existing limitation)
- Dashboard already passed locale correctly before this PR (no changes needed)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)