### PR TITLE
test: add e2e tests for admin AI provider UI

### DIFF
--- a/e2e/admin-ai-provider-ui.spec.ts
+++ b/e2e/admin-ai-provider-ui.spec.ts
@@ -89,7 +89,7 @@ test.describe("AI Provider Test UI", () => {
   test("uploading an invalid file type does not enable provider buttons", async ({
     page,
   }) => {
-    const section = await goToAdminAndWaitForProviderSection(page);
+    await goToAdminAndWaitForProviderSection(page);
 
     // Upload a .txt file (not an accepted image type)
     const txtPath = resolve("e2e/receipts/cafe.txt");
@@ -108,7 +108,7 @@ test.describe("AI Provider Test UI", () => {
   });
 
   test("changing image replaces the previous file", async ({ page }) => {
-    const section = await goToAdminAndWaitForProviderSection(page);
+    await goToAdminAndWaitForProviderSection(page);
 
     await page.getByTestId("ai-test-file-input").setInputFiles(RECEIPT_PATH);
     await expect(page.getByTestId("ai-test-file-info")).toContainText("coffee-shop.png");
@@ -122,7 +122,7 @@ test.describe("AI Provider Test UI", () => {
 
 test.describe("AI Provider Test — OCR via UI", () => {
   test.beforeEach(({}, testInfo) => {
-    if (process.env.RUN_AI_TESTS !== "1")
+    if (!process.env.RUN_AI_TESTS)
       testInfo.skip(true, "Set RUN_AI_TESTS=1 to enable");
   });
   test.setTimeout(150_000);
@@ -130,7 +130,7 @@ test.describe("AI Provider Test — OCR via UI", () => {
   test("clicking Test ocr shows success result with JSON", async ({
     page,
   }) => {
-    const section = await goToAdminAndWaitForProviderSection(page);
+    await goToAdminAndWaitForProviderSection(page);
 
     await page.getByTestId("ai-test-file-input").setInputFiles(RECEIPT_PATH);
     const ocrButton = page.getByTestId("ai-test-btn-ocr");
@@ -153,7 +153,7 @@ test.describe("AI Provider Test — OCR via UI", () => {
   });
 
   test("result JSON contains expected receipt fields", async ({ page }) => {
-    const section = await goToAdminAndWaitForProviderSection(page);
+    await goToAdminAndWaitForProviderSection(page);
 
     await page.getByTestId("ai-test-file-input").setInputFiles(RECEIPT_PATH);
     await expect(page.getByTestId("ai-test-file-info")).toBeVisible();

--- a/e2e/admin-ai-provider-ui.spec.ts
+++ b/e2e/admin-ai-provider-ui.spec.ts
@@ -1,0 +1,183 @@
+import { test, expect, type Page } from "@playwright/test";
+import { resolve } from "path";
+import { users, login } from "./helpers";
+
+const RECEIPT_PATH = resolve("e2e/receipts/coffee-shop.png");
+
+async function goToAdminAndWaitForProviderSection(page: Page) {
+  await login(page, users.alice.email, users.alice.password);
+  await page.goto("/admin");
+  const section = page.getByTestId("ai-provider-test-section");
+  await expect(section).toBeVisible({ timeout: 15000 });
+  return section;
+}
+
+test.describe("AI Provider Test UI", () => {
+  test("section renders with upload button and disabled provider buttons", async ({
+    page,
+  }) => {
+    const section = await goToAdminAndWaitForProviderSection(page);
+
+    await expect(page.getByTestId("ai-test-upload-btn")).toBeVisible();
+    await expect(page.getByTestId("ai-test-upload-hint")).toBeVisible();
+
+    // Provider buttons should exist but be disabled
+    const buttonContainer = page.getByTestId("ai-test-provider-buttons");
+    const testButtons = buttonContainer.locator("button");
+    const count = await testButtons.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+    for (let i = 0; i < count; i++) {
+      await expect(testButtons.nth(i)).toBeDisabled();
+    }
+  });
+
+  test("uploading a receipt image shows filename and enables provider buttons", async ({
+    page,
+  }) => {
+    const section = await goToAdminAndWaitForProviderSection(page);
+
+    await page.getByTestId("ai-test-file-input").setInputFiles(RECEIPT_PATH);
+
+    // File info should appear
+    const fileInfo = page.getByTestId("ai-test-file-info");
+    await expect(fileInfo).toBeVisible();
+    await expect(fileInfo).toContainText("coffee-shop.png");
+
+    // Hint text should be gone
+    await expect(page.getByTestId("ai-test-upload-hint")).not.toBeVisible();
+
+    // Upload button label should change
+    await expect(page.getByTestId("ai-test-upload-btn")).toContainText("Change Image");
+
+    // Provider buttons should now be enabled
+    const buttonContainer = page.getByTestId("ai-test-provider-buttons");
+    const testButtons = buttonContainer.locator("button");
+    const count = await testButtons.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+    for (let i = 0; i < count; i++) {
+      await expect(testButtons.nth(i)).toBeEnabled();
+    }
+  });
+
+  test("clearing uploaded file resets state", async ({ page }) => {
+    const section = await goToAdminAndWaitForProviderSection(page);
+
+    await page.getByTestId("ai-test-file-input").setInputFiles(RECEIPT_PATH);
+    await expect(page.getByTestId("ai-test-file-info")).toBeVisible();
+
+    // Click the clear button
+    await page.getByTestId("ai-test-clear-btn").click();
+
+    // File info should be gone
+    await expect(page.getByTestId("ai-test-file-info")).not.toBeVisible();
+
+    // Upload button should show original label
+    await expect(page.getByTestId("ai-test-upload-btn")).toContainText("Upload Receipt Image");
+
+    // Hint should reappear
+    await expect(page.getByTestId("ai-test-upload-hint")).toBeVisible();
+
+    // Provider buttons should be disabled again
+    const buttonContainer = page.getByTestId("ai-test-provider-buttons");
+    const testButtons = buttonContainer.locator("button");
+    const count = await testButtons.count();
+    for (let i = 0; i < count; i++) {
+      await expect(testButtons.nth(i)).toBeDisabled();
+    }
+  });
+
+  test("uploading an invalid file type does not enable provider buttons", async ({
+    page,
+  }) => {
+    const section = await goToAdminAndWaitForProviderSection(page);
+
+    // Upload a .txt file (not an accepted image type)
+    const txtPath = resolve("e2e/receipts/cafe.txt");
+    await page.getByTestId("ai-test-file-input").setInputFiles(txtPath);
+
+    // Wait a beat for any async processing
+    await page.waitForTimeout(500);
+
+    // Hint text should still be visible (file was rejected client-side)
+    await expect(page.getByTestId("ai-test-upload-hint")).toBeVisible();
+
+    // Provider buttons should remain disabled
+    const buttonContainer = page.getByTestId("ai-test-provider-buttons");
+    const testButtons = buttonContainer.locator("button");
+    const count = await testButtons.count();
+    for (let i = 0; i < count; i++) {
+      await expect(testButtons.nth(i)).toBeDisabled();
+    }
+  });
+
+  test("changing image replaces the previous file", async ({ page }) => {
+    const section = await goToAdminAndWaitForProviderSection(page);
+
+    await page.getByTestId("ai-test-file-input").setInputFiles(RECEIPT_PATH);
+    await expect(page.getByTestId("ai-test-file-info")).toContainText("coffee-shop.png");
+
+    // Upload a different file
+    const secondPath = resolve("e2e/receipts/fast-food.png");
+    await page.getByTestId("ai-test-file-input").setInputFiles(secondPath);
+    await expect(page.getByTestId("ai-test-file-info")).toContainText("fast-food.png");
+  });
+});
+
+test.describe("AI Provider Test — OCR via UI", () => {
+  test.beforeEach(({}, testInfo) => {
+    if (!process.env.RUN_AI_TESTS)
+      testInfo.skip(true, "Set RUN_AI_TESTS=1 to enable");
+  });
+  test.setTimeout(150_000);
+
+  test("clicking Test ocr shows success result with JSON", async ({
+    page,
+  }) => {
+    const section = await goToAdminAndWaitForProviderSection(page);
+
+    await page.getByTestId("ai-test-file-input").setInputFiles(RECEIPT_PATH);
+    await expect(page.getByTestId("ai-test-file-info")).toBeVisible();
+
+    // Click Test ocr
+    const ocrButton = page.getByTestId("ai-test-btn-ocr");
+    await expect(ocrButton).toBeEnabled();
+    await ocrButton.click();
+
+    // Should show spinner while loading
+    await expect(section.locator(".animate-spin")).toBeVisible({ timeout: 5000 });
+
+    // Wait for success result
+    const successMsg = page.getByTestId("ai-test-success-msg");
+    await expect(successMsg).toBeVisible({ timeout: 120_000 });
+    await expect(successMsg).toContainText("ocr responded in");
+
+    // JSON result should render
+    const pre = page.getByTestId("ai-test-result-json");
+    await expect(pre).toBeVisible();
+    const jsonText = await pre.textContent();
+    expect(jsonText).toBeTruthy();
+    const parsed = JSON.parse(jsonText!);
+    expect(parsed.items).toBeDefined();
+    expect(parsed.total).toBeGreaterThan(0);
+  });
+
+  test("result JSON contains expected receipt fields", async ({ page }) => {
+    const section = await goToAdminAndWaitForProviderSection(page);
+
+    await page.getByTestId("ai-test-file-input").setInputFiles(RECEIPT_PATH);
+
+    await page.getByTestId("ai-test-btn-ocr").click();
+
+    const pre = page.getByTestId("ai-test-result-json");
+    await expect(pre).toBeVisible({ timeout: 120_000 });
+
+    const parsed = JSON.parse((await pre.textContent())!);
+    expect(parsed.items.length).toBeGreaterThanOrEqual(1);
+    expect(typeof parsed.total).toBe("number");
+    expect(parsed.total).toBeGreaterThan(0);
+    for (const item of parsed.items) {
+      expect(item.description).toBeTruthy();
+      expect(typeof item.amount).toBe("number");
+    }
+  });
+});

--- a/e2e/admin-ai-provider-ui.spec.ts
+++ b/e2e/admin-ai-provider-ui.spec.ts
@@ -95,9 +95,6 @@ test.describe("AI Provider Test UI", () => {
     const txtPath = resolve("e2e/receipts/cafe.txt");
     await page.getByTestId("ai-test-file-input").setInputFiles(txtPath);
 
-    // Wait a beat for any async processing
-    await page.waitForTimeout(500);
-
     // Hint text should still be visible (file was rejected client-side)
     await expect(page.getByTestId("ai-test-upload-hint")).toBeVisible();
 
@@ -125,7 +122,7 @@ test.describe("AI Provider Test UI", () => {
 
 test.describe("AI Provider Test — OCR via UI", () => {
   test.beforeEach(({}, testInfo) => {
-    if (!process.env.RUN_AI_TESTS)
+    if (process.env.RUN_AI_TESTS !== "1")
       testInfo.skip(true, "Set RUN_AI_TESTS=1 to enable");
   });
   test.setTimeout(150_000);
@@ -136,15 +133,9 @@ test.describe("AI Provider Test — OCR via UI", () => {
     const section = await goToAdminAndWaitForProviderSection(page);
 
     await page.getByTestId("ai-test-file-input").setInputFiles(RECEIPT_PATH);
-    await expect(page.getByTestId("ai-test-file-info")).toBeVisible();
-
-    // Click Test ocr
     const ocrButton = page.getByTestId("ai-test-btn-ocr");
     await expect(ocrButton).toBeEnabled();
     await ocrButton.click();
-
-    // Should show spinner while loading
-    await expect(section.locator(".animate-spin")).toBeVisible({ timeout: 5000 });
 
     // Wait for success result
     const successMsg = page.getByTestId("ai-test-success-msg");
@@ -165,8 +156,11 @@ test.describe("AI Provider Test — OCR via UI", () => {
     const section = await goToAdminAndWaitForProviderSection(page);
 
     await page.getByTestId("ai-test-file-input").setInputFiles(RECEIPT_PATH);
+    await expect(page.getByTestId("ai-test-file-info")).toBeVisible();
 
-    await page.getByTestId("ai-test-btn-ocr").click();
+    const ocrButton = page.getByTestId("ai-test-btn-ocr");
+    await expect(ocrButton).toBeEnabled();
+    await ocrButton.click();
 
     const pre = page.getByTestId("ai-test-result-json");
     await expect(pre).toBeVisible({ timeout: 120_000 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     {
       name: "serial",
       testMatch: [
+        "admin-ai-provider-ui.spec.ts",
         "admin-features.spec.ts",
         "admin-meridian.spec.ts",
         "ai-provider-test.spec.ts",
@@ -39,6 +40,7 @@ export default defineConfig({
     {
       name: "parallel",
       testIgnore: [
+        "admin-ai-provider-ui.spec.ts",
         "admin-features.spec.ts",
         "admin-meridian.spec.ts",
         "ai-provider-test.spec.ts",

--- a/src/components/admin/ai-provider-test-section.tsx
+++ b/src/components/admin/ai-provider-test-section.tsx
@@ -124,7 +124,7 @@ export function AIProviderTestSection() {
             {file && (
               <div className="flex items-center gap-2 text-sm text-muted-foreground" data-testid="ai-test-file-info">
                 <span className="max-w-48 truncate">{file.name}</span>
-                <button onClick={clearFile} className="text-muted-foreground hover:text-foreground" data-testid="ai-test-clear-btn">
+                <button type="button" onClick={clearFile} className="text-muted-foreground hover:text-foreground" data-testid="ai-test-clear-btn" aria-label="Clear file">
                   <X className="h-4 w-4" />
                 </button>
               </div>

--- a/src/components/admin/ai-provider-test-section.tsx
+++ b/src/components/admin/ai-provider-test-section.tsx
@@ -90,7 +90,7 @@ export function AIProviderTestSection() {
   }
 
   return (
-    <section>
+    <section data-testid="ai-provider-test-section">
       <div className="mb-4 flex items-center gap-2">
         <FlaskConical className="h-5 w-5 text-muted-foreground" />
         <h2 className="text-lg font-semibold">Other Provider Tests</h2>
@@ -110,26 +110,28 @@ export function AIProviderTestSection() {
               accept={ACCEPTED_TYPES.join(',')}
               onChange={handleFileChange}
               className="hidden"
+              data-testid="ai-test-file-input"
             />
             <Button
               size="sm"
               variant="outline"
               onClick={() => fileRef.current?.click()}
+              data-testid="ai-test-upload-btn"
             >
               <Upload className="mr-2 h-4 w-4" />
               {file ? 'Change Image' : 'Upload Receipt Image'}
             </Button>
             {file && (
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground" data-testid="ai-test-file-info">
                 <span className="max-w-48 truncate">{file.name}</span>
-                <button onClick={clearFile} className="text-muted-foreground hover:text-foreground">
+                <button onClick={clearFile} className="text-muted-foreground hover:text-foreground" data-testid="ai-test-clear-btn">
                   <X className="h-4 w-4" />
                 </button>
               </div>
             )}
           </div>
 
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-2" data-testid="ai-test-provider-buttons">
             {nonOAuthProviders.map((name) => (
               <Button
                 key={name}
@@ -137,6 +139,7 @@ export function AIProviderTestSection() {
                 variant="outline"
                 disabled={!file || testProvider.isPending}
                 onClick={() => handleTest(name)}
+                data-testid={`ai-test-btn-${name}`}
               >
                 {testProvider.isPending && activeProvider === name ? (
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -149,26 +152,26 @@ export function AIProviderTestSection() {
           </div>
 
           {!file && (
-            <p className="text-sm text-muted-foreground">
+            <p className="text-sm text-muted-foreground" data-testid="ai-test-upload-hint">
               Upload a receipt image to enable testing.
             </p>
           )}
 
           {testProvider.isSuccess && (
-            <div className="space-y-2">
-              <p className="flex items-center gap-1 text-sm text-green-600">
+            <div className="space-y-2" data-testid="ai-test-success">
+              <p className="flex items-center gap-1 text-sm text-green-600" data-testid="ai-test-success-msg">
                 <CheckCircle2 className="h-4 w-4" />
                 {activeProvider} responded in {testProvider.data.durationMs}ms
               </p>
-              <pre className="max-h-96 overflow-auto rounded-md bg-muted p-3 text-xs">
+              <pre className="max-h-96 overflow-auto rounded-md bg-muted p-3 text-xs" data-testid="ai-test-result-json">
                 {JSON.stringify(testProvider.data.result, null, 2)}
               </pre>
             </div>
           )}
 
           {testProvider.isError && (
-            <div className="space-y-2">
-              <p className="flex items-center gap-1 text-sm text-destructive">
+            <div className="space-y-2" data-testid="ai-test-error">
+              <p className="flex items-center gap-1 text-sm text-destructive" data-testid="ai-test-error-msg">
                 <AlertCircle className="h-4 w-4" />
                 {activeProvider} failed: {testProvider.error.message}
               </p>


### PR DESCRIPTION
## Summary
- Add UI-level e2e tests for the `AIProviderTestSection` component (5 always-run + 2 gated by `RUN_AI_TESTS=1`)
- Add `data-testid` attributes to `ai-provider-test-section.tsx` for stable test selectors
- Tests cover: section rendering, file upload/clear flow, invalid file rejection, image replacement, OCR result rendering

## Test plan
- [x] All 5 UI tests pass (`npx playwright test e2e/admin-ai-provider-ui.spec.ts --no-deps`)
- [x] OCR tests correctly skip without `RUN_AI_TESTS=1`
- [x] Unit tests pass (239/239)
- [x] Lint clean (no new issues)
- [ ] Verify with `RUN_AI_TESTS=1` for OCR tests (requires running AI provider)

Closes #88