### PR TITLE
feat: split line items for per-person quantity claiming

### DIFF
--- a/src/app/[locale]/split/page.tsx
+++ b/src/app/[locale]/split/page.tsx
@@ -787,6 +787,7 @@ export default function GuestSplitPage() {
                               }}
                               className="text-muted-foreground hover:text-foreground p-1"
                               title="Split into separate line"
+                              aria-label={`Split ${item.name} into separate line`}
                             >
                               <Scissors className="h-3 w-3" />
                             </button>

--- a/src/app/[locale]/split/page.tsx
+++ b/src/app/[locale]/split/page.tsx
@@ -15,7 +15,7 @@ import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
   Camera, Loader2, Plus, Trash2, Check, Users, ArrowLeft, ArrowRight,
-  Share2, Copy, Pencil, Image as ImageIcon, RefreshCw,
+  Share2, Copy, Pencil, Image as ImageIcon, RefreshCw, Scissors,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -65,6 +65,10 @@ export default function GuestSplitPage() {
   const [editValues, setEditValues] = useState({ name: "", quantity: "1", totalPrice: "" });
   const [addingItem, setAddingItem] = useState(false);
   const [newItem, setNewItem] = useState({ name: "", quantity: "1", totalPrice: "" });
+
+  // Splitting
+  const [splittingIndex, setSplittingIndex] = useState<number | null>(null);
+  const [splitQuantity, setSplitQuantity] = useState("");
 
   // tRPC
   const processReceipt = trpc.guest.processReceipt.useMutation();
@@ -258,6 +262,40 @@ export default function GuestSplitPage() {
     }]);
     setAddingItem(false);
     setNewItem({ name: "", quantity: "1", totalPrice: "" });
+  }
+
+  // Split item into two rows
+  function handleSplitItem(index: number) {
+    const qty = parseInt(splitQuantity) || 1;
+    const item = items[index];
+    if (!item || qty < 1 || qty >= item.quantity) return;
+
+    const newTotalPrice = item.unitPrice * qty;
+    const remainingQty = item.quantity - qty;
+    const remainingTotalPrice = item.totalPrice - newTotalPrice;
+
+    const updated = [...items];
+    updated[index] = { ...item, quantity: remainingQty, totalPrice: remainingTotalPrice };
+    updated.splice(index + 1, 0, {
+      name: item.name,
+      quantity: qty,
+      unitPrice: item.unitPrice,
+      totalPrice: newTotalPrice,
+    });
+    setItems(updated);
+
+    // Shift assignments: indices after the insertion point need to be incremented
+    const newAssignments: Record<number, Set<number>> = {};
+    for (const [key, value] of Object.entries(assignments)) {
+      const k = parseInt(key);
+      if (k > index) {
+        newAssignments[k + 1] = value;
+      } else {
+        newAssignments[k] = value;
+      }
+    }
+    setAssignments(newAssignments);
+    setSplittingIndex(null);
   }
 
   // Calculate totals
@@ -740,8 +778,48 @@ export default function GuestSplitPage() {
                           >
                             <Trash2 className="h-3 w-3" />
                           </button>
+                          {item.quantity > 1 && (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setSplittingIndex(itemIdx);
+                                setSplitQuantity("1");
+                              }}
+                              className="text-muted-foreground hover:text-foreground p-1"
+                              title="Split into separate line"
+                            >
+                              <Scissors className="h-3 w-3" />
+                            </button>
+                          )}
                         </div>
                         <span className="font-semibold">{formatCents(item.totalPrice, currency, locale)}</span>
+                      </div>
+                    )}
+                    {/* Inline split form */}
+                    {splittingIndex === itemIdx && (
+                      <div className="mb-2 flex items-center gap-2">
+                        <span className="text-xs text-muted-foreground">Split off</span>
+                        <Input
+                          type="number"
+                          min={1}
+                          max={item.quantity - 1}
+                          value={splitQuantity}
+                          onChange={(e) => setSplitQuantity(e.target.value)}
+                          className="w-16 h-7 text-xs"
+                        />
+                        <span className="text-xs text-muted-foreground">of {item.quantity}</span>
+                        <Button
+                          type="button"
+                          size="sm"
+                          className="h-7 text-xs"
+                          disabled={!splitQuantity || parseInt(splitQuantity) < 1 || parseInt(splitQuantity) >= item.quantity}
+                          onClick={() => handleSplitItem(itemIdx)}
+                        >
+                          Split
+                        </Button>
+                        <Button type="button" variant="ghost" size="sm" className="h-7 text-xs" onClick={() => setSplittingIndex(null)}>
+                          Cancel
+                        </Button>
                       </div>
                     )}
                     {/* Person toggle buttons */}

--- a/src/app/[locale]/split/page.tsx
+++ b/src/app/[locale]/split/page.tsx
@@ -266,9 +266,9 @@ export default function GuestSplitPage() {
 
   // Split item into two rows
   function handleSplitItem(index: number) {
-    const qty = parseInt(splitQuantity) || 1;
+    const qty = Number(splitQuantity);
     const item = items[index];
-    if (!item || qty < 1 || qty >= item.quantity) return;
+    if (!item || !Number.isSafeInteger(qty) || qty < 1 || qty >= item.quantity) return;
 
     const newTotalPrice = item.unitPrice * qty;
     const remainingQty = item.quantity - qty;
@@ -796,32 +796,36 @@ export default function GuestSplitPage() {
                       </div>
                     )}
                     {/* Inline split form */}
-                    {splittingIndex === itemIdx && (
-                      <div className="mb-2 flex items-center gap-2">
-                        <span className="text-xs text-muted-foreground">Split off</span>
-                        <Input
-                          type="number"
-                          min={1}
-                          max={item.quantity - 1}
-                          value={splitQuantity}
-                          onChange={(e) => setSplitQuantity(e.target.value)}
-                          className="w-16 h-7 text-xs"
-                        />
-                        <span className="text-xs text-muted-foreground">of {item.quantity}</span>
-                        <Button
-                          type="button"
-                          size="sm"
-                          className="h-7 text-xs"
-                          disabled={!splitQuantity || parseInt(splitQuantity) < 1 || parseInt(splitQuantity) >= item.quantity}
-                          onClick={() => handleSplitItem(itemIdx)}
-                        >
-                          Split
-                        </Button>
-                        <Button type="button" variant="ghost" size="sm" className="h-7 text-xs" onClick={() => setSplittingIndex(null)}>
-                          Cancel
-                        </Button>
-                      </div>
-                    )}
+                    {splittingIndex === itemIdx && (() => {
+                      const parsed = Number(splitQuantity);
+                      const validQty = Number.isSafeInteger(parsed) && parsed >= 1 && parsed < item.quantity;
+                      return (
+                        <div className="mb-2 flex items-center gap-2">
+                          <span className="text-xs text-muted-foreground">Split off</span>
+                          <Input
+                            type="number"
+                            min={1}
+                            max={item.quantity - 1}
+                            value={splitQuantity}
+                            onChange={(e) => setSplitQuantity(e.target.value)}
+                            className="w-16 h-7 text-xs"
+                          />
+                          <span className="text-xs text-muted-foreground">of {item.quantity}</span>
+                          <Button
+                            type="button"
+                            size="sm"
+                            className="h-7 text-xs"
+                            disabled={!validQty}
+                            onClick={() => handleSplitItem(itemIdx)}
+                          >
+                            Split
+                          </Button>
+                          <Button type="button" variant="ghost" size="sm" className="h-7 text-xs" onClick={() => setSplittingIndex(null)}>
+                            Cancel
+                          </Button>
+                        </div>
+                      );
+                    })()}
                     {/* Person toggle buttons */}
                     <div className="flex flex-wrap gap-1.5">
                       {people.map((name, personIdx) => {

--- a/src/components/receipts/item-assignment.tsx
+++ b/src/components/receipts/item-assignment.tsx
@@ -551,6 +551,7 @@ export function ItemAssignment({
                           }}
                           className="text-muted-foreground hover:text-foreground"
                           title="Split into separate line"
+                          aria-label={`Split ${item.name} into separate line`}
                         >
                           <Scissors className="h-3 w-3" />
                         </button>

--- a/src/components/receipts/item-assignment.tsx
+++ b/src/components/receipts/item-assignment.tsx
@@ -10,7 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { Check, Users, Pencil, Trash2, Plus, Image as ImageIcon } from "lucide-react";
+import { Check, Users, Pencil, Trash2, Plus, Image as ImageIcon, Scissors } from "lucide-react";
 
 type Member = { id: string; name: string | null };
 
@@ -46,6 +46,8 @@ export function ItemAssignment({
   const [editValues, setEditValues] = useState<{ name: string; quantity: string; totalPrice: string }>({ name: "", quantity: "", totalPrice: "" });
   const [addingItem, setAddingItem] = useState(false);
   const [newItem, setNewItem] = useState({ name: "", quantity: "1", totalPrice: "" });
+  const [splittingItem, setSplittingItem] = useState<string | null>(null);
+  const [splitQuantity, setSplitQuantity] = useState("");
 
   const createExpense = trpc.receipts.assignItemsAndCreateExpense.useMutation({
     onSuccess: onComplete,
@@ -65,6 +67,9 @@ export function ItemAssignment({
       setNewItem({ name: "", quantity: "1", totalPrice: "" });
       utils.receipts.getReceiptItems.invalidate({ receiptId });
     },
+  });
+  const splitItem = trpc.receipts.splitItem.useMutation({
+    onSuccess: () => utils.receipts.getReceiptItems.invalidate({ receiptId }),
   });
 
   // Reset zoom/pan when image is hidden
@@ -537,10 +542,52 @@ export function ItemAssignment({
                       >
                         <Trash2 className="h-3 w-3" />
                       </button>
+                      {item.quantity > 1 && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setSplittingItem(item.id);
+                            setSplitQuantity("1");
+                          }}
+                          className="text-muted-foreground hover:text-foreground"
+                          title="Split into separate line"
+                        >
+                          <Scissors className="h-3 w-3" />
+                        </button>
+                      )}
                     </div>
                     <span className="font-semibold">
                       {formatCents(item.totalPrice, extracted.currency, locale)}
                     </span>
+                  </div>
+                )}
+                {!isEditing && splittingItem === item.id && (
+                  <div className="mb-2 flex items-center gap-2">
+                    <span className="text-xs text-muted-foreground">Split off</span>
+                    <Input
+                      type="number"
+                      min={1}
+                      max={item.quantity - 1}
+                      value={splitQuantity}
+                      onChange={(e) => setSplitQuantity(e.target.value)}
+                      className="w-16 h-7 text-xs"
+                    />
+                    <span className="text-xs text-muted-foreground">of {item.quantity}</span>
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="h-7 text-xs"
+                      disabled={splitItem.isPending || !splitQuantity || parseInt(splitQuantity) < 1 || parseInt(splitQuantity) >= item.quantity}
+                      onClick={() => {
+                        splitItem.mutate({ itemId: item.id, splitQuantity: parseInt(splitQuantity) || 1 });
+                        setSplittingItem(null);
+                      }}
+                    >
+                      Split
+                    </Button>
+                    <Button type="button" variant="ghost" size="sm" className="h-7 text-xs" onClick={() => setSplittingItem(null)}>
+                      Cancel
+                    </Button>
                   </div>
                 )}
                 <div className="flex flex-wrap gap-1.5">

--- a/src/components/receipts/item-assignment.tsx
+++ b/src/components/receipts/item-assignment.tsx
@@ -561,35 +561,40 @@ export function ItemAssignment({
                     </span>
                   </div>
                 )}
-                {!isEditing && splittingItem === item.id && (
-                  <div className="mb-2 flex items-center gap-2">
-                    <span className="text-xs text-muted-foreground">Split off</span>
-                    <Input
-                      type="number"
-                      min={1}
-                      max={item.quantity - 1}
-                      value={splitQuantity}
-                      onChange={(e) => setSplitQuantity(e.target.value)}
-                      className="w-16 h-7 text-xs"
-                    />
-                    <span className="text-xs text-muted-foreground">of {item.quantity}</span>
-                    <Button
-                      type="button"
-                      size="sm"
-                      className="h-7 text-xs"
-                      disabled={splitItem.isPending || !splitQuantity || parseInt(splitQuantity) < 1 || parseInt(splitQuantity) >= item.quantity}
-                      onClick={() => {
-                        splitItem.mutate({ itemId: item.id, splitQuantity: parseInt(splitQuantity) || 1 });
-                        setSplittingItem(null);
-                      }}
-                    >
-                      Split
-                    </Button>
-                    <Button type="button" variant="ghost" size="sm" className="h-7 text-xs" onClick={() => setSplittingItem(null)}>
-                      Cancel
-                    </Button>
-                  </div>
-                )}
+                {!isEditing && splittingItem === item.id && (() => {
+                  const parsed = Number(splitQuantity);
+                  const validQty = Number.isSafeInteger(parsed) && parsed >= 1 && parsed < item.quantity;
+                  return (
+                    <div className="mb-2 flex items-center gap-2">
+                      <span className="text-xs text-muted-foreground">Split off</span>
+                      <Input
+                        type="number"
+                        min={1}
+                        max={item.quantity - 1}
+                        value={splitQuantity}
+                        onChange={(e) => setSplitQuantity(e.target.value)}
+                        className="w-16 h-7 text-xs"
+                      />
+                      <span className="text-xs text-muted-foreground">of {item.quantity}</span>
+                      <Button
+                        type="button"
+                        size="sm"
+                        className="h-7 text-xs"
+                        disabled={splitItem.isPending || !validQty}
+                        onClick={() => {
+                          if (!validQty) return;
+                          splitItem.mutate({ itemId: item.id, splitQuantity: parsed });
+                          setSplittingItem(null);
+                        }}
+                      >
+                        Split
+                      </Button>
+                      <Button type="button" variant="ghost" size="sm" className="h-7 text-xs" onClick={() => setSplittingItem(null)}>
+                        Cancel
+                      </Button>
+                    </div>
+                  );
+                })()}
                 <div className="flex flex-wrap gap-1.5">
                   {members.map((m) => {
                     const isAssigned = assigned.has(m.id);

--- a/src/server/trpc/routers/receipts.ts
+++ b/src/server/trpc/routers/receipts.ts
@@ -252,6 +252,13 @@ export const receiptsRouter = createTRPCRouter({
           where: { id: input.itemId },
         });
 
+        if (input.splitQuantity >= current.quantity) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Split quantity must be less than total quantity",
+          });
+        }
+
         const newTotalPrice = current.unitPrice * input.splitQuantity;
         const remainingQuantity = current.quantity - input.splitQuantity;
         const remainingTotalPrice = current.totalPrice - newTotalPrice;

--- a/src/server/trpc/routers/receipts.ts
+++ b/src/server/trpc/routers/receipts.ts
@@ -226,6 +226,63 @@ export const receiptsRouter = createTRPCRouter({
       return { success: true };
     }),
 
+  splitItem: protectedProcedure
+    .input(
+      z.object({
+        itemId: z.string(),
+        splitQuantity: z.number().int().min(1),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const item = await ctx.db.receiptItem.findUnique({
+        where: { id: input.itemId },
+      });
+      if (!item) throw new TRPCError({ code: "NOT_FOUND" });
+      await verifyReceiptAccess(ctx.db, item.receiptId, ctx.user.id);
+
+      if (input.splitQuantity >= item.quantity) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Split quantity must be less than total quantity",
+        });
+      }
+
+      const newTotalPrice = item.unitPrice * input.splitQuantity;
+      const remainingQuantity = item.quantity - input.splitQuantity;
+      const remainingTotalPrice = item.totalPrice - newTotalPrice;
+
+      // Shift sortOrders to make room for the new item
+      await ctx.db.receiptItem.updateMany({
+        where: {
+          receiptId: item.receiptId,
+          sortOrder: { gt: item.sortOrder },
+        },
+        data: { sortOrder: { increment: 1 } },
+      });
+
+      const [, newItem] = await ctx.db.$transaction([
+        ctx.db.receiptItem.update({
+          where: { id: input.itemId },
+          data: {
+            quantity: remainingQuantity,
+            totalPrice: remainingTotalPrice,
+          },
+        }),
+        ctx.db.receiptItem.create({
+          data: {
+            receiptId: item.receiptId,
+            name: item.name,
+            quantity: input.splitQuantity,
+            unitPrice: item.unitPrice,
+            totalPrice: newTotalPrice,
+            sortOrder: item.sortOrder + 1,
+          },
+        }),
+      ]);
+
+      return newItem;
+    }),
+
   updateExtractedData: protectedProcedure
     .input(
       z.object({

--- a/src/server/trpc/routers/receipts.ts
+++ b/src/server/trpc/routers/receipts.ts
@@ -247,40 +247,42 @@ export const receiptsRouter = createTRPCRouter({
         });
       }
 
-      const newTotalPrice = item.unitPrice * input.splitQuantity;
-      const remainingQuantity = item.quantity - input.splitQuantity;
-      const remainingTotalPrice = item.totalPrice - newTotalPrice;
+      return ctx.db.$transaction(async (tx) => {
+        const current = await tx.receiptItem.findUniqueOrThrow({
+          where: { id: input.itemId },
+        });
 
-      // Shift sortOrders to make room for the new item
-      await ctx.db.receiptItem.updateMany({
-        where: {
-          receiptId: item.receiptId,
-          sortOrder: { gt: item.sortOrder },
-        },
-        data: { sortOrder: { increment: 1 } },
-      });
+        const newTotalPrice = current.unitPrice * input.splitQuantity;
+        const remainingQuantity = current.quantity - input.splitQuantity;
+        const remainingTotalPrice = current.totalPrice - newTotalPrice;
 
-      const [, newItem] = await ctx.db.$transaction([
-        ctx.db.receiptItem.update({
+        await tx.receiptItem.updateMany({
+          where: {
+            receiptId: current.receiptId,
+            sortOrder: { gt: current.sortOrder },
+          },
+          data: { sortOrder: { increment: 1 } },
+        });
+
+        await tx.receiptItem.update({
           where: { id: input.itemId },
           data: {
             quantity: remainingQuantity,
             totalPrice: remainingTotalPrice,
           },
-        }),
-        ctx.db.receiptItem.create({
-          data: {
-            receiptId: item.receiptId,
-            name: item.name,
-            quantity: input.splitQuantity,
-            unitPrice: item.unitPrice,
-            totalPrice: newTotalPrice,
-            sortOrder: item.sortOrder + 1,
-          },
-        }),
-      ]);
+        });
 
-      return newItem;
+        return tx.receiptItem.create({
+          data: {
+            receiptId: current.receiptId,
+            name: current.name,
+            quantity: input.splitQuantity,
+            unitPrice: current.unitPrice,
+            totalPrice: newTotalPrice,
+            sortOrder: current.sortOrder + 1,
+          },
+        });
+      });
     }),
 
   updateExtractedData: protectedProcedure


### PR DESCRIPTION
## Summary
- Add ability to split multi-quantity receipt items into separate rows (e.g., "7x Beer $35" → "3x Beer $15" + "4x Beer $20")
- Each split row can then be assigned to different people independently
- Scissors icon appears on items with quantity > 1, inline form for specifying split quantity
- Works in both authenticated (DB-backed) and guest (client-side) flows

## Changes
- **Backend**: `splitItem` mutation in receipts router — atomic transaction, sort order shifting, price computation from unit price
- **Authenticated flow**: `item-assignment.tsx` — scissors button, inline split form, tRPC mutation
- **Guest flow**: `split/page.tsx` — client-side array splice with assignment index shifting

## Test plan
- [x] Unit tests pass (239/239)
- [x] TypeScript clean (no new errors)
- [x] Lint clean (no new issues)
- [ ] Manual: upload receipt with multi-quantity item, split it, verify two rows appear with correct prices
- [ ] Manual: assign split rows to different people, verify per-person totals are correct
- [ ] Manual: test guest split flow with same scenario
- [ ] Manual: verify split button hidden when quantity = 1