### PR TITLE
fix: split item edge cases (rounded prices, index shift)

### DIFF
--- a/src/app/[locale]/split/page.tsx
+++ b/src/app/[locale]/split/page.tsx
@@ -270,7 +270,7 @@ export default function GuestSplitPage() {
     const item = items[index];
     if (!item || !Number.isSafeInteger(qty) || qty < 1 || qty >= item.quantity) return;
 
-    const newTotalPrice = item.unitPrice * qty;
+    const newTotalPrice = Math.min(item.unitPrice * qty, item.totalPrice - 1);
     const remainingQty = item.quantity - qty;
     const remainingTotalPrice = item.totalPrice - newTotalPrice;
 
@@ -295,6 +295,11 @@ export default function GuestSplitPage() {
       }
     }
     setAssignments(newAssignments);
+
+    // Shift index-based UI state so edits don't target the wrong item
+    if (editingItem !== null && editingItem > index) {
+      setEditingItem(editingItem + 1);
+    }
     setSplittingIndex(null);
   }
 

--- a/src/app/[locale]/split/page.tsx
+++ b/src/app/[locale]/split/page.tsx
@@ -270,9 +270,14 @@ export default function GuestSplitPage() {
     const item = items[index];
     if (!item || !Number.isSafeInteger(qty) || qty < 1 || qty >= item.quantity) return;
 
-    const newTotalPrice = Math.min(item.unitPrice * qty, item.totalPrice - 1);
+    const maxNewTotal = item.totalPrice - 1;
+    if (maxNewTotal <= 0) return;
+
+    const newTotalPrice = Math.min(item.unitPrice * qty, maxNewTotal);
     const remainingQty = item.quantity - qty;
     const remainingTotalPrice = item.totalPrice - newTotalPrice;
+
+    if (newTotalPrice <= 0 || remainingTotalPrice <= 0) return;
 
     const updated = [...items];
     updated[index] = { ...item, quantity: remainingQty, totalPrice: remainingTotalPrice };
@@ -297,9 +302,7 @@ export default function GuestSplitPage() {
     setAssignments(newAssignments);
 
     // Shift index-based UI state so edits don't target the wrong item
-    if (editingItem !== null && editingItem > index) {
-      setEditingItem(editingItem + 1);
-    }
+    setEditingItem((prev) => (prev !== null && prev > index ? prev + 1 : prev));
     setSplittingIndex(null);
   }
 

--- a/src/server/trpc/routers/receipts.ts
+++ b/src/server/trpc/routers/receipts.ts
@@ -259,9 +259,17 @@ export const receiptsRouter = createTRPCRouter({
           });
         }
 
-        const newTotalPrice = current.unitPrice * input.splitQuantity;
+        const rawNewTotal = current.unitPrice * input.splitQuantity;
+        const newTotalPrice = Math.min(rawNewTotal, current.totalPrice - 1);
         const remainingQuantity = current.quantity - input.splitQuantity;
         const remainingTotalPrice = current.totalPrice - newTotalPrice;
+
+        if (remainingTotalPrice <= 0 || newTotalPrice <= 0) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Split would result in invalid price distribution",
+          });
+        }
 
         await tx.receiptItem.updateMany({
           where: {

--- a/src/server/trpc/routers/receipts.ts
+++ b/src/server/trpc/routers/receipts.ts
@@ -259,12 +259,19 @@ export const receiptsRouter = createTRPCRouter({
           });
         }
 
-        const rawNewTotal = current.unitPrice * input.splitQuantity;
-        const newTotalPrice = Math.min(rawNewTotal, current.totalPrice - 1);
+        const maxNewTotal = current.totalPrice - 1;
+        if (maxNewTotal <= 0) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Item price too low to split",
+          });
+        }
+
+        const newTotalPrice = Math.min(current.unitPrice * input.splitQuantity, maxNewTotal);
         const remainingQuantity = current.quantity - input.splitQuantity;
         const remainingTotalPrice = current.totalPrice - newTotalPrice;
 
-        if (remainingTotalPrice <= 0 || newTotalPrice <= 0) {
+        if (newTotalPrice <= 0 || remainingTotalPrice <= 0) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: "Split would result in invalid price distribution",


### PR DESCRIPTION
## Summary
Fixes two P1 issues from Codex review on #92 that landed after merge:

- **Rounded unit price overflow**: `unitPrice * splitQuantity` could exceed `totalPrice` when unitPrice was rounded, making `remainingTotalPrice` negative. Now caps `newTotalPrice` and rejects splits that would result in zero/negative amounts on either side.
- **Guest split index corruption**: Splitting an item before an item being edited would leave `editingItem` pointing at the wrong index. Now shifts `editingItem` when the insertion point is before it.

## Test plan
- [x] Unit tests pass (239/239)
- [ ] Manual: split an item where `unitPrice * qty > totalPrice` (e.g., 3x item at $3.33 each, total $9.99 — split off 2)
- [ ] Manual: edit item name on guest split, then split an earlier item, verify edit still targets the correct item