### PR TITLE
feat: add collaborative claiming to group receipt scan

### DIFF
--- a/messages/de/expenses.json
+++ b/messages/de/expenses.json
@@ -46,7 +46,10 @@
     "cancel": "Abbrechen",
     "uploading": "Wird hochgeladen...",
     "activeProvider": "Aktiver Anbieter:",
-    "fallbackChain": "Fallback-Kette:"
+    "fallbackChain": "Fallback-Kette:",
+    "or": "oder",
+    "shareForClaiming": "Link teilen — Mitglieder wählen lassen",
+    "creatingSession": "Sitzung wird erstellt..."
   },
   "receipt": {
     "hideImage": "Belegbild ausblenden",

--- a/messages/en/expenses.json
+++ b/messages/en/expenses.json
@@ -46,7 +46,10 @@
     "cancel": "Cancel",
     "uploading": "Uploading...",
     "activeProvider": "Active provider:",
-    "fallbackChain": "Fallback chain:"
+    "fallbackChain": "Fallback chain:",
+    "or": "or",
+    "shareForClaiming": "Share Link — Let Members Claim Items",
+    "creatingSession": "Creating session..."
   },
   "receipt": {
     "hideImage": "Hide Receipt Image",

--- a/messages/es/expenses.json
+++ b/messages/es/expenses.json
@@ -46,7 +46,10 @@
     "cancel": "Cancelar",
     "uploading": "Subiendo...",
     "activeProvider": "Proveedor activo:",
-    "fallbackChain": "Cadena de respaldo:"
+    "fallbackChain": "Cadena de respaldo:",
+    "or": "o",
+    "shareForClaiming": "Compartir enlace — Dejar que los miembros reclamen artículos",
+    "creatingSession": "Creando sesión..."
   },
   "receipt": {
     "hideImage": "Ocultar imagen del recibo",

--- a/messages/fr/expenses.json
+++ b/messages/fr/expenses.json
@@ -46,7 +46,10 @@
     "cancel": "Annuler",
     "uploading": "Envoi en cours...",
     "activeProvider": "Fournisseur actif :",
-    "fallbackChain": "Chaîne de secours :"
+    "fallbackChain": "Chaîne de secours :",
+    "or": "ou",
+    "shareForClaiming": "Partager le lien — Laissez les membres choisir",
+    "creatingSession": "Création de la session..."
   },
   "receipt": {
     "hideImage": "Masquer l'image du reçu",

--- a/messages/ja/expenses.json
+++ b/messages/ja/expenses.json
@@ -46,7 +46,10 @@
     "cancel": "キャンセル",
     "uploading": "アップロード中...",
     "activeProvider": "使用中のプロバイダ:",
-    "fallbackChain": "フォールバックチェーン:"
+    "fallbackChain": "フォールバックチェーン:",
+    "or": "または",
+    "shareForClaiming": "リンクを共有 — メンバーに選んでもらう",
+    "creatingSession": "セッションを作成中..."
   },
   "receipt": {
     "hideImage": "レシート画像を非表示",

--- a/messages/ko/expenses.json
+++ b/messages/ko/expenses.json
@@ -46,7 +46,10 @@
     "cancel": "취소",
     "uploading": "업로드 중...",
     "activeProvider": "활성 제공자:",
-    "fallbackChain": "폴백 체인:"
+    "fallbackChain": "폴백 체인:",
+    "or": "또는",
+    "shareForClaiming": "링크 공유 — 멤버가 직접 선택",
+    "creatingSession": "세션 생성 중..."
   },
   "receipt": {
     "hideImage": "영수증 이미지 숨기기",

--- a/messages/pt-BR/expenses.json
+++ b/messages/pt-BR/expenses.json
@@ -46,7 +46,10 @@
     "cancel": "Cancelar",
     "uploading": "Enviando...",
     "activeProvider": "Provedor ativo:",
-    "fallbackChain": "Cadeia de fallback:"
+    "fallbackChain": "Cadeia de fallback:",
+    "or": "ou",
+    "shareForClaiming": "Compartilhar link — Deixe os membros escolherem",
+    "creatingSession": "Criando sessão..."
   },
   "receipt": {
     "hideImage": "Ocultar imagem do recibo",

--- a/messages/sv/expenses.json
+++ b/messages/sv/expenses.json
@@ -46,7 +46,10 @@
     "cancel": "Avbryt",
     "uploading": "Laddar upp...",
     "activeProvider": "Aktiv leverantör:",
-    "fallbackChain": "Reservkedja:"
+    "fallbackChain": "Reservkedja:",
+    "or": "eller",
+    "shareForClaiming": "Dela länk — Låt medlemmar välja artiklar",
+    "creatingSession": "Skapar session..."
   },
   "receipt": {
     "hideImage": "Dölj kvittobild",

--- a/messages/zh-CN/expenses.json
+++ b/messages/zh-CN/expenses.json
@@ -46,7 +46,10 @@
     "cancel": "取消",
     "uploading": "上传中...",
     "activeProvider": "当前提供商：",
-    "fallbackChain": "备用链："
+    "fallbackChain": "备用链：",
+    "or": "或",
+    "shareForClaiming": "分享链接 — 让成员自行选择",
+    "creatingSession": "正在创建会话..."
   },
   "receipt": {
     "hideImage": "隐藏小票图片",

--- a/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
@@ -10,6 +10,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ArrowLeft, Loader2, Camera, RefreshCw, Users } from "lucide-react";
+import { useSession } from "next-auth/react";
+import { toast } from "sonner";
 import { ItemAssignment } from "@/components/receipts/item-assignment";
 import { loadingMessages } from "@/lib/loading-messages";
 
@@ -36,6 +38,7 @@ function ScanReceiptContent({
   const router = useRouter();
   const searchParams = useSearchParams();
   const t = useTranslations("expenses.scan");
+  const { data: authSession } = useSession();
   const resumeReceiptId = searchParams.get("receiptId");
   const group = trpc.groups.get.useQuery({ groupId });
   const providerInfo = trpc.receipts.getScanProviderInfo.useQuery();
@@ -81,6 +84,8 @@ function ScanReceiptContent({
     const currentMembers = members.filter((m) => m.name);
     if (currentMembers.length < 1) return;
 
+    const myName = authSession?.user?.name ?? currentMembers[0]?.name ?? "Unknown";
+
     try {
       const result = await shareForClaiming.mutateAsync({
         receiptId,
@@ -90,7 +95,7 @@ function ScanReceiptContent({
           subtotal: extracted.subtotal,
           tax: extracted.tax,
           tip: extracted.tip ?? 0,
-          total: extracted.subtotal + extracted.tax + (extracted.tip ?? 0),
+          total: extracted.total ?? (extracted.subtotal + extracted.tax + (extracted.tip ?? 0)),
           currency: extracted.currency ?? "USD",
         },
         items: items.map((i) => ({
@@ -99,12 +104,12 @@ function ScanReceiptContent({
           unitPrice: i.unitPrice,
           totalPrice: i.totalPrice,
         })),
-        creatorName: currentMembers[0].name,
-        paidByName: currentMembers[0].name,
+        creatorName: myName,
+        paidByName: myName,
       });
       router.push(`/split/${result.shareToken}/claim`);
-    } catch {
-      // Error handled by mutation
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to create claiming session");
     }
   }
 

--- a/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
@@ -251,7 +251,7 @@ function ScanReceiptContent({
             variant="outline"
             className="w-full"
             onClick={handleShareForClaiming}
-            disabled={shareForClaiming.isPending || !receiptData.data?.receipt?.extractedData || members.length < 1}
+            disabled={shareForClaiming.isPending || !receiptData.data?.receipt?.extractedData || !receiptData.data?.items?.length || members.length < 1}
             data-testid="group-share-claiming-btn"
           >
             <Users className="mr-2 h-4 w-4" />

--- a/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
@@ -84,7 +84,9 @@ function ScanReceiptContent({
     const currentMembers = members.filter((m) => m.name);
     if (currentMembers.length < 1) return;
 
-    const myName = authSession?.user?.name ?? currentMembers[0]?.name ?? "Unknown";
+    const myId = authSession?.user?.id;
+    const myMember = myId ? currentMembers.find(m => m.id === myId) : undefined;
+    const myName = myMember?.name ?? authSession?.user?.name ?? currentMembers[0]?.name ?? "Unknown";
 
     try {
       const result = await shareForClaiming.mutateAsync({

--- a/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { ArrowLeft, Loader2, Camera, RefreshCw } from "lucide-react";
+import { ArrowLeft, Loader2, Camera, RefreshCw, Users } from "lucide-react";
 import { ItemAssignment } from "@/components/receipts/item-assignment";
 import { loadingMessages } from "@/lib/loading-messages";
 
@@ -66,6 +66,47 @@ function ScanReceiptContent({
     },
   });
 
+  const shareForClaiming = trpc.guest.createClaimSession.useMutation();
+  const receiptData = trpc.receipts.getReceiptItems.useQuery(
+    { receiptId: receiptId! },
+    { enabled: step === "assign" && !!receiptId }
+  );
+
+  async function handleShareForClaiming() {
+    if (!receiptId || !receiptData.data) return;
+    const { receipt, items } = receiptData.data;
+    const extracted = receipt.extractedData;
+    if (!extracted) return;
+
+    const currentMembers = members.filter((m) => m.name);
+    if (currentMembers.length < 1) return;
+
+    try {
+      const result = await shareForClaiming.mutateAsync({
+        receiptId,
+        receiptData: {
+          merchantName: extracted.merchantName,
+          date: extracted.date,
+          subtotal: extracted.subtotal,
+          tax: extracted.tax,
+          tip: extracted.tip ?? 0,
+          total: extracted.subtotal + extracted.tax + (extracted.tip ?? 0),
+          currency: extracted.currency ?? "USD",
+        },
+        items: items.map((i) => ({
+          name: i.name,
+          quantity: i.quantity,
+          unitPrice: i.unitPrice,
+          totalPrice: i.totalPrice,
+        })),
+        creatorName: currentMembers[0].name,
+        paidByName: currentMembers[0].name,
+      });
+      router.push(`/split/${result.shareToken}/claim`);
+    } catch {
+      // Error handled by mutation
+    }
+  }
 
   async function handleFileUpload(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -194,6 +235,21 @@ function ScanReceiptContent({
             onComplete={handleExpenseCreated}
             onSaveForLater={() => router.push(`/groups/${groupId}`)}
           />
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <div className="flex-1 h-px bg-border" />
+            <span className="text-xs">{t("or")}</span>
+            <div className="flex-1 h-px bg-border" />
+          </div>
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={handleShareForClaiming}
+            disabled={shareForClaiming.isPending}
+            data-testid="group-share-claiming-btn"
+          >
+            <Users className="mr-2 h-4 w-4" />
+            {shareForClaiming.isPending ? t("creatingSession") : t("shareForClaiming")}
+          </Button>
           <div className="space-y-2">
             {!showRescan ? (
               <Button

--- a/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
@@ -251,7 +251,7 @@ function ScanReceiptContent({
             variant="outline"
             className="w-full"
             onClick={handleShareForClaiming}
-            disabled={shareForClaiming.isPending || !receiptData.data?.receipt?.extractedData || !receiptData.data?.items?.length || members.length < 1}
+            disabled={shareForClaiming.isPending || !authSession?.user?.id || !receiptData.data?.receipt?.extractedData || !receiptData.data?.items?.length || members.length < 1}
             data-testid="group-share-claiming-btn"
           >
             <Users className="mr-2 h-4 w-4" />

--- a/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
@@ -251,7 +251,7 @@ function ScanReceiptContent({
             variant="outline"
             className="w-full"
             onClick={handleShareForClaiming}
-            disabled={shareForClaiming.isPending}
+            disabled={shareForClaiming.isPending || !receiptData.data?.receipt?.extractedData || members.length < 1}
             data-testid="group-share-claiming-btn"
           >
             <Users className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- Adds "Share Link — Let Members Claim Items" button to the group receipt scan page
- When clicked, creates a claiming session from the scanned receipt data
- Uses the current user's name (from session + group membership) as creator/paidBy
- Other group members join via the shared link and claim their own items
- Button disabled until receipt data is loaded and group has members
- Errors surfaced via toast notification
- Translations added for all 9 locales

## Test plan
- [x] TypeScript compiles cleanly
- [x] 239 unit tests pass
- [x] i18n lint passes
- [ ] Scan a receipt in a group, click "Share for Claiming", verify claim page opens
- [ ] Share the claim link with another group member, verify they can join and claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)