### PR TITLE
fix: dead code removal, backend cleanup, and consistency

### DIFF
--- a/e2e/expired-session.spec.ts
+++ b/e2e/expired-session.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect, request } from "@playwright/test";
+import { trpcMutation, trpcError } from "./helpers";
+
+const BASE = process.env.BASE_URL || "http://localhost:3001";
+
+async function createSessionWithToken() {
+  const ctx = await request.newContext({ baseURL: BASE });
+
+  const createRes = await trpcMutation(ctx, "guest.createClaimSession", {
+    receiptData: {
+      merchantName: "Guard Test",
+      subtotal: 1000,
+      tax: 100,
+      tip: 0,
+      total: 1100,
+      currency: "USD",
+    },
+    items: [{ name: "Item", quantity: 1, unitPrice: 1000, totalPrice: 1000 }],
+    creatorName: "Alice",
+    paidByName: "Bob",
+  });
+  const shareToken = (await createRes.json()).result?.data?.json?.shareToken;
+
+  const joinRes = await trpcMutation(ctx, "guest.joinSession", {
+    token: shareToken,
+    name: "Alice",
+  });
+  const { personToken } = (await joinRes.json()).result?.data?.json;
+
+  return { ctx, shareToken, personToken };
+}
+
+test.describe("Session mutation guards — finalized", () => {
+  test("editPersonName rejects finalized sessions", async () => {
+    const { ctx, shareToken, personToken } = await createSessionWithToken();
+
+    await trpcMutation(ctx, "guest.finalizeSession", {
+      token: shareToken, personIndex: 0, personToken,
+    });
+
+    const res = await trpcMutation(ctx, "guest.editPersonName", {
+      token: shareToken, personToken, targetIndex: 0, newName: "Carol",
+    });
+    expect((await trpcError(res))?.data?.code).toBe("BAD_REQUEST");
+    await ctx.dispose();
+  });
+
+  test("removePerson rejects finalized sessions", async () => {
+    const { ctx, shareToken, personToken } = await createSessionWithToken();
+
+    await trpcMutation(ctx, "guest.finalizeSession", {
+      token: shareToken, personIndex: 0, personToken,
+    });
+
+    const res = await trpcMutation(ctx, "guest.removePerson", {
+      token: shareToken, personToken, targetIndex: 1,
+    });
+    expect((await trpcError(res))?.data?.code).toBe("BAD_REQUEST");
+    await ctx.dispose();
+  });
+
+  test("splitClaimItem rejects finalized sessions", async () => {
+    const { ctx, shareToken, personToken } = await createSessionWithToken();
+
+    await trpcMutation(ctx, "guest.finalizeSession", {
+      token: shareToken, personIndex: 0, personToken,
+    });
+
+    const res = await trpcMutation(ctx, "guest.splitClaimItem", {
+      token: shareToken, personToken, itemIndex: 0, splitQuantity: 1,
+    });
+    expect((await trpcError(res))?.data?.code).toBe("BAD_REQUEST");
+    await ctx.dispose();
+  });
+});
+
+test.describe("Session mutation guards — expired", () => {
+  test("editPersonName rejects expired sessions", async () => {
+    const { ctx, shareToken, personToken } = await createSessionWithToken();
+
+    await trpcMutation(ctx, "guest._testExpireSession", { token: shareToken });
+
+    const res = await trpcMutation(ctx, "guest.editPersonName", {
+      token: shareToken, personToken, targetIndex: 0, newName: "Carol",
+    });
+    const err = await trpcError(res);
+    expect(err?.data?.code).toBe("NOT_FOUND");
+    await ctx.dispose();
+  });
+
+  test("removePerson rejects expired sessions", async () => {
+    const { ctx, shareToken, personToken } = await createSessionWithToken();
+
+    await trpcMutation(ctx, "guest._testExpireSession", { token: shareToken });
+
+    const res = await trpcMutation(ctx, "guest.removePerson", {
+      token: shareToken, personToken, targetIndex: 1,
+    });
+    const err = await trpcError(res);
+    expect(err?.data?.code).toBe("NOT_FOUND");
+    await ctx.dispose();
+  });
+
+  test("splitClaimItem rejects expired sessions", async () => {
+    const { ctx, shareToken, personToken } = await createSessionWithToken();
+
+    await trpcMutation(ctx, "guest._testExpireSession", { token: shareToken });
+
+    const res = await trpcMutation(ctx, "guest.splitClaimItem", {
+      token: shareToken, personToken, itemIndex: 0, splitQuantity: 1,
+    });
+    const err = await trpcError(res);
+    expect(err?.data?.code).toBe("NOT_FOUND");
+    await ctx.dispose();
+  });
+
+  test("joinSession rejects expired sessions", async () => {
+    const { ctx, shareToken } = await createSessionWithToken();
+
+    await trpcMutation(ctx, "guest._testExpireSession", { token: shareToken });
+
+    const res = await trpcMutation(ctx, "guest.joinSession", {
+      token: shareToken, name: "Carol",
+    });
+    const err = await trpcError(res);
+    expect(err?.data?.code).toBe("NOT_FOUND");
+    await ctx.dispose();
+  });
+
+  test("claimItems rejects expired sessions", async () => {
+    const { ctx, shareToken, personToken } = await createSessionWithToken();
+
+    await trpcMutation(ctx, "guest._testExpireSession", { token: shareToken });
+
+    const res = await trpcMutation(ctx, "guest.claimItems", {
+      token: shareToken, personIndex: 0, personToken, claimedItemIndices: [0],
+    });
+    const err = await trpcError(res);
+    expect(err?.data?.code).toBe("NOT_FOUND");
+    await ctx.dispose();
+  });
+
+  test("finalizeSession rejects expired sessions", async () => {
+    const { ctx, shareToken, personToken } = await createSessionWithToken();
+
+    await trpcMutation(ctx, "guest._testExpireSession", { token: shareToken });
+
+    const res = await trpcMutation(ctx, "guest.finalizeSession", {
+      token: shareToken, personIndex: 0, personToken,
+    });
+    const err = await trpcError(res);
+    expect(err?.data?.code).toBe("NOT_FOUND");
+    await ctx.dispose();
+  });
+
+  test("getSession rejects expired sessions", async () => {
+    const { ctx, shareToken } = await createSessionWithToken();
+
+    await trpcMutation(ctx, "guest._testExpireSession", { token: shareToken });
+
+    const res = await request.newContext({ baseURL: BASE });
+    const getRes = await res.get(
+      `/api/trpc/guest.getSession?batch=1&input=${encodeURIComponent(JSON.stringify({ "0": { json: { token: shareToken } } }))}`
+    );
+    const body = await getRes.json();
+    const error = body[0]?.error;
+    expect(error?.json?.data?.code).toBe("NOT_FOUND");
+    await ctx.dispose();
+    await res.dispose();
+  });
+});

--- a/e2e/stale-total.spec.ts
+++ b/e2e/stale-total.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, request } from "@playwright/test";
+import { trpcMutation, trpcQuery, trpcResult } from "./helpers";
+
+const BASE = process.env.BASE_URL || "http://localhost:3001";
+
+test.describe("createSplit total with tipOverride", () => {
+  test("stored total reflects tipOverride, not original tip", async () => {
+    const ctx = await request.newContext({ baseURL: BASE });
+
+    // Receipt: subtotal 2000, tax 200, tip 100, total 2300
+    // Override tip to 500 → expected total = 2000 + 200 + 500 = 2700
+    const createRes = await trpcMutation(ctx, "guest.createSplit", {
+      receiptData: {
+        merchantName: "Tip Override Test",
+        subtotal: 2000,
+        tax: 200,
+        tip: 100,
+        total: 2300,
+        currency: "USD",
+      },
+      items: [
+        { name: "Burger", quantity: 1, unitPrice: 2000, totalPrice: 2000 },
+      ],
+      people: [{ name: "Alice" }],
+      assignments: [{ itemIndex: 0, personIndices: [0] }],
+      paidByIndex: 0,
+      tipOverride: 500,
+    });
+    expect(createRes.ok()).toBe(true);
+    const { shareToken } = (await createRes.json()).result?.data?.json;
+
+    // Fetch the split and check stored receiptData.total
+    const getRes = await trpcQuery(ctx, "guest.getSplit", { token: shareToken });
+    const data = await trpcResult(getRes);
+
+    // The stored tip should be the override value
+    expect(data.receiptData.tip).toBe(500);
+    // The stored total should be recalculated: subtotal + tax + overriddenTip
+    expect(data.receiptData.total).toBe(2700);
+
+    // Summary totals should also sum to the correct total
+    const summaryTotal = data.summary.reduce(
+      (sum: number, s: { total: number }) => sum + s.total,
+      0
+    );
+    expect(summaryTotal).toBe(2700);
+
+    await ctx.dispose();
+  });
+
+  test("stored total preserved when no tipOverride is provided", async () => {
+    const ctx = await request.newContext({ baseURL: BASE });
+
+    const createRes = await trpcMutation(ctx, "guest.createSplit", {
+      receiptData: {
+        merchantName: "No Override Test",
+        subtotal: 2000,
+        tax: 200,
+        tip: 100,
+        total: 2300,
+        currency: "USD",
+      },
+      items: [
+        { name: "Salad", quantity: 1, unitPrice: 2000, totalPrice: 2000 },
+      ],
+      people: [{ name: "Alice" }],
+      assignments: [{ itemIndex: 0, personIndices: [0] }],
+      paidByIndex: 0,
+    });
+    expect(createRes.ok()).toBe(true);
+    const { shareToken } = (await createRes.json()).result?.data?.json;
+
+    const getRes = await trpcQuery(ctx, "guest.getSplit", { token: shareToken });
+    const data = await trpcResult(getRes);
+
+    expect(data.receiptData.tip).toBe(100);
+    expect(data.receiptData.total).toBe(2300);
+
+    await ctx.dispose();
+  });
+});

--- a/messages/de/splits.json
+++ b/messages/de/splits.json
@@ -12,5 +12,6 @@
   "untitled": "Unbenannte Teilung",
   "delete": "Split löschen",
   "deleteConfirm": "Diesen Split löschen? Dies kann nicht rückgängig gemacht werden.",
-  "deleted": "Split gelöscht"
+  "deleted": "Split gelöscht",
+  "loading": "Laden..."
 }

--- a/messages/en/splits.json
+++ b/messages/en/splits.json
@@ -12,5 +12,6 @@
   "untitled": "Untitled split",
   "delete": "Delete split",
   "deleteConfirm": "Delete this split? This cannot be undone.",
-  "deleted": "Split deleted"
+  "deleted": "Split deleted",
+  "loading": "Loading..."
 }

--- a/messages/es/splits.json
+++ b/messages/es/splits.json
@@ -12,5 +12,6 @@
   "untitled": "Division sin titulo",
   "delete": "Eliminar división",
   "deleteConfirm": "¿Eliminar esta división? Esta acción no se puede deshacer.",
-  "deleted": "División eliminada"
+  "deleted": "División eliminada",
+  "loading": "Cargando..."
 }

--- a/messages/fr/splits.json
+++ b/messages/fr/splits.json
@@ -12,5 +12,6 @@
   "untitled": "Partage sans titre",
   "delete": "Supprimer le partage",
   "deleteConfirm": "Supprimer ce partage ? Cette action est irréversible.",
-  "deleted": "Partage supprimé"
+  "deleted": "Partage supprimé",
+  "loading": "Chargement..."
 }

--- a/messages/ja/splits.json
+++ b/messages/ja/splits.json
@@ -12,5 +12,6 @@
   "untitled": "無題の割り勘",
   "delete": "分割を削除",
   "deleteConfirm": "この分割を削除しますか？元に戻せません。",
-  "deleted": "分割を削除しました"
+  "deleted": "分割を削除しました",
+  "loading": "読み込み中..."
 }

--- a/messages/ko/splits.json
+++ b/messages/ko/splits.json
@@ -12,5 +12,6 @@
   "untitled": "제목 없는 정산",
   "delete": "분할 삭제",
   "deleteConfirm": "이 분할을 삭제하시겠습니까? 되돌릴 수 없습니다.",
-  "deleted": "분할이 삭제되었습니다"
+  "deleted": "분할이 삭제되었습니다",
+  "loading": "로딩 중..."
 }

--- a/messages/pt-BR/splits.json
+++ b/messages/pt-BR/splits.json
@@ -12,5 +12,6 @@
   "untitled": "Divisao sem titulo",
   "delete": "Excluir divisão",
   "deleteConfirm": "Excluir esta divisão? Esta ação não pode ser desfeita.",
-  "deleted": "Divisão excluída"
+  "deleted": "Divisão excluída",
+  "loading": "Carregando..."
 }

--- a/messages/sv/splits.json
+++ b/messages/sv/splits.json
@@ -12,5 +12,6 @@
   "untitled": "Namnlos delning",
   "delete": "Ta bort delning",
   "deleteConfirm": "Ta bort denna delning? Detta kan inte ångras.",
-  "deleted": "Delning borttagen"
+  "deleted": "Delning borttagen",
+  "loading": "Laddar..."
 }

--- a/messages/zh-CN/splits.json
+++ b/messages/zh-CN/splits.json
@@ -12,5 +12,6 @@
   "untitled": "未命名分账",
   "delete": "删除分账",
   "deleteConfirm": "删除此分账？此操作无法撤销。",
-  "deleted": "分账已删除"
+  "deleted": "分账已删除",
+  "loading": "加载中..."
 }

--- a/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
@@ -132,8 +132,12 @@ function ScanReceiptContent({
       });
 
       if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error ?? "Upload failed");
+        let message = "Upload failed";
+        try {
+          const data = await res.json();
+          message = data.error ?? message;
+        } catch {}
+        throw new Error(message);
       }
 
       const data = await res.json();

--- a/src/app/[locale]/(app)/splits/page.tsx
+++ b/src/app/[locale]/(app)/splits/page.tsx
@@ -48,7 +48,7 @@ export default function SplitsPage() {
         </Button>
       </div>
 
-      {isLoading && <p className="text-muted-foreground">Loading...</p>}
+      {isLoading && <p className="text-muted-foreground">{t("loading")}</p>}
 
       {!isLoading && splits.length === 0 && (
         <Card data-testid="splits-empty">

--- a/src/app/[locale]/split/[token]/claim/page.tsx
+++ b/src/app/[locale]/split/[token]/claim/page.tsx
@@ -99,15 +99,51 @@ export default function ClaimPage({
   });
 
   const removePerson = trpc.guest.removePerson.useMutation({
-    onSuccess: () => toast.success(t("personRemoved")),
+    onSuccess: (_data, variables) => {
+      const removedIdx = variables.targetIndex;
+      // Reset local claimed items — server has remapped indices (Finding #3)
+      setClaimedItems(new Map());
+      // Adjust personIndex / myPersonIndex to match server's new indices
+      setPersonIndex((prev) => {
+        if (prev === null) return null;
+        if (prev === removedIdx) return 0;
+        return prev > removedIdx ? prev - 1 : prev;
+      });
+      setMyPersonIndex((prev) => {
+        if (prev === null) return null;
+        if (prev === removedIdx) return 0;
+        return prev > removedIdx ? prev - 1 : prev;
+      });
+      toast.success(t("personRemoved"));
+    },
     onError: (err) => toast.error(err.message),
   });
 
   const splitClaimItem = trpc.guest.splitClaimItem.useMutation({
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
+      const splitIdx = variables.itemIndex;
       setSplittingItemIdx(null);
       setSplitQty("");
-      setClaimedItems(new Map());
+      // Remap claimed item indices: items after the split point shift +1 (Finding #4).
+      // Only invalidate the split item itself; preserve unsaved edits for other items.
+      setClaimedItems((prev) => {
+        const next = new Map<number, Set<number>>();
+        for (const [personIdx, itemSet] of prev) {
+          const remapped = new Set<number>();
+          for (const itemIdx of itemSet) {
+            if (itemIdx === splitIdx) {
+              // Keep claim on the original (now-reduced) item
+              remapped.add(itemIdx);
+            } else if (itemIdx > splitIdx) {
+              remapped.add(itemIdx + 1);
+            } else {
+              remapped.add(itemIdx);
+            }
+          }
+          next.set(personIdx, remapped);
+        }
+        return next;
+      });
     },
     onError: (err) => toast.error(err.message),
   });

--- a/src/app/[locale]/split/[token]/claim/page.tsx
+++ b/src/app/[locale]/split/[token]/claim/page.tsx
@@ -566,7 +566,7 @@ export default function ClaimPage({
       {/* Header */}
       <div className="text-center space-y-1 pt-4">
         <h1 className="text-2xl font-bold">
-          {data.receiptData.merchantName ?? "Bill Split"}
+          {data.receiptData.merchantName ?? t("billSplit")}
         </h1>
         {data.receiptData.date && (
           <p className="text-sm text-muted-foreground">

--- a/src/app/[locale]/split/page.tsx
+++ b/src/app/[locale]/split/page.tsx
@@ -15,11 +15,11 @@ import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
   Camera, Loader2, Plus, Trash2, Check, Users, ArrowLeft, ArrowRight,
-  Share2, Copy, Pencil, Image as ImageIcon, RefreshCw, Scissors,
+  Share2, Pencil, Image as ImageIcon, RefreshCw, Scissors,
 } from "lucide-react";
 import { toast } from "sonner";
 
-type Step = "upload" | "processing" | "people" | "assign" | "review";
+type Step = "upload" | "processing" | "people" | "assign";
 
 type GuestItem = {
   name: string;
@@ -52,7 +52,6 @@ export default function GuestSplitPage() {
   const [items, setItems] = useState<GuestItem[]>([]);
   const [extracted, setExtracted] = useState<ExtractedData | null>(null);
   const [people, setPeople] = useState<string[]>([""]); // start with one empty name
-  const [newPersonName, setNewPersonName] = useState("");
   const [assignments, setAssignments] = useState<Record<number, Set<number>>>({}); // itemIdx -> Set<personIdx>
   const [paidByIndex, setPaidByIndex] = useState(0);
   const [tipOverride, setTipOverride] = useState("");
@@ -131,8 +130,12 @@ export default function GuestSplitPage() {
       });
 
       if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error ?? "Upload failed");
+        let message = "Upload failed";
+        try {
+          const data = await res.json();
+          message = data.error ?? message;
+        } catch {}
+        throw new Error(message);
       }
 
       const data = await res.json();
@@ -158,14 +161,6 @@ export default function GuestSplitPage() {
       setErrorMessage(err instanceof Error ? err.message : "Upload failed");
       setStep("upload");
     }
-  }
-
-  // People management
-  function addPerson() {
-    const name = newPersonName.trim();
-    if (!name) return;
-    setPeople((p) => [...p, name]);
-    setNewPersonName("");
   }
 
   function removePerson(idx: number) {
@@ -208,9 +203,13 @@ export default function GuestSplitPage() {
   }
 
   function assignAllToEveryone() {
+    const validIndices = people
+      .map((name, idx) => ({ name, idx }))
+      .filter((p) => p.name.trim())
+      .map((p) => p.idx);
     const next: Record<number, Set<number>> = {};
     for (let i = 0; i < items.length; i++) {
-      next[i] = new Set(people.map((_, idx) => idx));
+      next[i] = new Set(validIndices);
     }
     setAssignments(next);
   }
@@ -330,7 +329,7 @@ export default function GuestSplitPage() {
     });
   }, [items, assignments, extracted, tip, people.length]);
 
-  const perPersonTotals = step === "assign" || step === "review" ? getPerPersonTotals() : [];
+  const perPersonTotals = step === "assign" ? getPerPersonTotals() : [];
   const assignedCount = Object.values(assignments).filter((s) => s.size > 0).length;
   const allAssigned = assignedCount === items.length && items.length > 0;
   const validPeople = people.filter((n) => n.trim().length > 0);
@@ -338,12 +337,26 @@ export default function GuestSplitPage() {
   async function handleCreateSplit() {
     if (!extracted || !allAssigned || validPeople.length < 1) return;
 
+    // Build index mapping from unfiltered people → filtered validPeople
+    const indexMap = new Map<number, number>();
+    let validIdx = 0;
+    for (let i = 0; i < people.length; i++) {
+      if (people[i].trim()) {
+        indexMap.set(i, validIdx++);
+      }
+    }
+
     const assignmentList = Object.entries(assignments)
       .filter(([, s]) => s.size > 0)
       .map(([itemIdx, personSet]) => ({
         itemIndex: parseInt(itemIdx),
-        personIndices: Array.from(personSet),
-      }));
+        personIndices: Array.from(personSet)
+          .filter((pi) => indexMap.has(pi))
+          .map((pi) => indexMap.get(pi)!),
+      }))
+      .filter((a) => a.personIndices.length > 0);
+
+    const remappedPaidBy = indexMap.get(paidByIndex) ?? 0;
 
     try {
       const result = await createSplit.mutateAsync({
@@ -352,7 +365,7 @@ export default function GuestSplitPage() {
         items,
         people: validPeople.map((n) => ({ name: n })),
         assignments: assignmentList,
-        paidByIndex,
+        paidByIndex: remappedPaidBy,
         tipOverride: tipOverride !== "" ? Math.round(parseFloat(tipOverride) * 100) : undefined,
       });
       router.push(`/split/${result.shareToken}`);
@@ -369,8 +382,8 @@ export default function GuestSplitPage() {
         receiptId: receiptId ?? undefined,
         receiptData: { ...extracted, tip },
         items,
-        creatorName: validPeople[paidByIndex] || validPeople[0],
-        paidByName: validPeople[paidByIndex] || validPeople[0],
+        creatorName: people[paidByIndex]?.trim() || validPeople[0],
+        paidByName: people[paidByIndex]?.trim() || validPeople[0],
       });
       router.push(`/split/${result.shareToken}/claim`);
     } catch (err) {

--- a/src/components/receipts/item-assignment.tsx
+++ b/src/components/receipts/item-assignment.tsx
@@ -251,7 +251,7 @@ export function ItemAssignment({
 
   const perPersonTotals = getPerPersonTotals();
   const assignedItemCount = Object.values(assignments).filter((s) => s.size > 0).length;
-  const allAssigned = assignedItemCount === items.length;
+  const allAssigned = items.length > 0 && assignedItemCount === items.length;
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/src/server/trpc/routers/guest.ts
+++ b/src/server/trpc/routers/guest.ts
@@ -58,6 +58,51 @@ async function withSerializableRetry<T>(run: () => Promise<T>): Promise<T> {
   }
 }
 
+// ─── Shared Zod schemas (Finding #27) ────────────────────────────
+const receiptDataSchema = z.object({
+  merchantName: z.string().optional(),
+  date: z.string().optional(),
+  subtotal: z.number().int(),
+  tax: z.number().int(),
+  tip: z.number().int(),
+  total: z.number().int(),
+  currency: z.string().default("USD"),
+});
+
+const itemSchema = z.object({
+  name: z.string(),
+  quantity: z.number().int().min(1),
+  unitPrice: z.number().int(),
+  totalPrice: z.number().int(),
+});
+
+// ─── Shared helpers (Finding #28) ─────────────────────────────────
+/** Create a Date 7 days from now for guest split expiration. */
+function createExpiryDate(): Date {
+  const expiresAt = new Date();
+  expiresAt.setDate(expiresAt.getDate() + 7);
+  return expiresAt;
+}
+
+/** Fire-and-forget cleanup of expired GuestSplit records. */
+function cleanupExpiredSplits(
+  db: typeof import("@/server/db").db,
+  logPrefix: string
+): void {
+  db.guestSplit
+    .deleteMany({ where: { expiresAt: { lt: new Date() } } })
+    .then((result) => {
+      if (result.count > 0) {
+        logger.info(`${logPrefix}.cleanup`, { deletedCount: result.count });
+      }
+    })
+    .catch((err) => {
+      logger.warn(`${logPrefix}.cleanup.failed`, {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+}
+
 export const guestRouter = createTRPCRouter({
   // Test-only: expire a session for e2e testing the expiry guards
   ...(process.env.NODE_ENV === "test" ? {
@@ -236,7 +281,7 @@ export const guestRouter = createTRPCRouter({
         },
       });
       if (!receipt) {
-        throw new TRPCError({ code: "NOT_FOUND" });
+        throw new TRPCError({ code: "NOT_FOUND", message: "Receipt not found" });
       }
       if (!receipt.isGuest) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Receipt not found" });
@@ -264,21 +309,8 @@ export const guestRouter = createTRPCRouter({
   createSplit: publicProcedure
     .input(z.object({
       receiptId: z.string().optional(),
-      receiptData: z.object({
-        merchantName: z.string().optional(),
-        date: z.string().optional(),
-        subtotal: z.number().int(),
-        tax: z.number().int(),
-        tip: z.number().int(),
-        total: z.number().int(),
-        currency: z.string().default("USD"),
-      }),
-      items: z.array(z.object({
-        name: z.string(),
-        quantity: z.number().int().min(1),
-        unitPrice: z.number().int(),
-        totalPrice: z.number().int(),
-      })).max(100),
+      receiptData: receiptDataSchema,
+      items: z.array(itemSchema).max(100),
       people: z.array(z.object({ name: z.string() })).min(1).max(100),
       assignments: z.array(z.object({
         itemIndex: z.number().int(),
@@ -323,17 +355,8 @@ export const guestRouter = createTRPCRouter({
         .filter((a) => a.personIndices.length > 0);
       const remappedPaidBy = indexMap.get(input.paidByIndex) ?? 0;
 
-      // Validate index bounds (against filtered arrays)
-      for (const a of remappedAssignments) {
-        if (a.itemIndex < 0 || a.itemIndex >= input.items.length) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: `Invalid itemIndex: ${a.itemIndex}` });
-        }
-        for (const pi of a.personIndices) {
-          if (pi < 0 || pi >= filteredPeople.length) {
-            throw new TRPCError({ code: "BAD_REQUEST", message: `Invalid personIndex: ${pi}` });
-          }
-        }
-      }
+      // Note: second bounds-validation loop removed (Finding #13) — the remap above
+      // only produces valid indices via indexMap filtering, making post-remap validation redundant.
 
       const tip = input.tipOverride ?? input.receiptData.tip;
 
@@ -350,9 +373,6 @@ export const guestRouter = createTRPCRouter({
         name: filteredPeople[s.personIndex]?.name ?? `Person ${s.personIndex + 1}`,
       }));
 
-      const expiresAt = new Date();
-      expiresAt.setDate(expiresAt.getDate() + 7);
-
       const guestSplit = await ctx.db.guestSplit.create({
         data: {
           receiptId: input.receiptId,
@@ -367,24 +387,11 @@ export const guestRouter = createTRPCRouter({
           summary: summaryWithNames as unknown as Prisma.InputJsonValue,
           paidByIndex: remappedPaidBy,
           userId: ctx.session?.user?.id ?? null,
-          expiresAt,
+          expiresAt: createExpiryDate(),
         },
       });
 
-      // Opportunistic cleanup: delete expired GuestSplit records to prevent unbounded growth.
-      // Piggybacked on createSplit to avoid needing a separate cron job.
-      ctx.db.guestSplit
-        .deleteMany({ where: { expiresAt: { lt: new Date() } } })
-        .then((result) => {
-          if (result.count > 0) {
-            logger.info("guest.split.cleanup", { deletedCount: result.count });
-          }
-        })
-        .catch((err) => {
-          logger.warn("guest.split.cleanup.failed", {
-            error: err instanceof Error ? err.message : "Unknown",
-          });
-        });
+      cleanupExpiredSplits(ctx.db, "guest.split");
 
       logger.info("guest.split.created", {
         splitId: guestSplit.id,
@@ -442,27 +449,12 @@ export const guestRouter = createTRPCRouter({
   createClaimSession: publicProcedure
     .input(z.object({
       receiptId: z.string().optional(),
-      receiptData: z.object({
-        merchantName: z.string().optional(),
-        date: z.string().optional(),
-        subtotal: z.number().int(),
-        tax: z.number().int(),
-        tip: z.number().int(),
-        total: z.number().int(),
-        currency: z.string().default("USD"),
-      }),
-      items: z.array(z.object({
-        name: z.string(),
-        quantity: z.number().int().min(1),
-        unitPrice: z.number().int(),
-        totalPrice: z.number().int(),
-      })).min(1).max(100),
+      receiptData: receiptDataSchema,
+      items: z.array(itemSchema).min(1).max(100),
       creatorName: z.string().trim().min(1).max(100),
       paidByName: z.string().trim().min(1).max(100),
     }))
     .mutation(async ({ ctx, input }) => {
-      const expiresAt = new Date();
-      expiresAt.setDate(expiresAt.getDate() + 7);
       const creatorName = input.creatorName.trim();
       const paidByName = input.paidByName.trim();
 
@@ -511,23 +503,11 @@ export const guestRouter = createTRPCRouter({
           paidByIndex,
           status: "claiming",
           userId: ctx.session?.user?.id ?? null,
-          expiresAt,
+          expiresAt: createExpiryDate(),
         },
       });
 
-      // Opportunistic cleanup: delete expired GuestSplit records.
-      ctx.db.guestSplit
-        .deleteMany({ where: { expiresAt: { lt: new Date() } } })
-        .then((result) => {
-          if (result.count > 0) {
-            logger.info("guest.session.cleanup", { deletedCount: result.count });
-          }
-        })
-        .catch((err) => {
-          logger.warn("guest.session.cleanup.failed", {
-            error: err instanceof Error ? err.message : String(err),
-          });
-        });
+      cleanupExpiredSplits(ctx.db, "guest.session");
 
       logger.info("guest.session.created", {
         sessionId: session.id,
@@ -600,6 +580,10 @@ export const guestRouter = createTRPCRouter({
       newName: z.string().trim().min(1).max(100),
     }))
     .mutation(async ({ ctx, input }) => {
+      const { allowed } = checkRateLimit(`guest-edit-name:${input.token}`, 10, 60 * 1000);
+      if (!allowed) {
+        throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: "Too many requests. Please try again shortly." });
+      }
       return withSerializableRetry(() =>
         ctx.db.$transaction(async (tx) => {
           const session = await tx.guestSplit.findUnique({
@@ -635,6 +619,10 @@ export const guestRouter = createTRPCRouter({
       targetIndex: z.number().int().min(0),
     }))
     .mutation(async ({ ctx, input }) => {
+      const { allowed } = checkRateLimit(`guest-remove-person:${input.token}`, 10, 60 * 1000);
+      if (!allowed) {
+        throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: "Too many requests. Please try again shortly." });
+      }
       return withSerializableRetry(() =>
         ctx.db.$transaction(async (tx) => {
           const session = await tx.guestSplit.findUnique({
@@ -683,6 +671,10 @@ export const guestRouter = createTRPCRouter({
       );
     }),
 
+  // Note (Finding #12): createClaimSession auto-splits multi-quantity items to qty=1,
+  // so this endpoint is unreachable for sessions created by current code. However, it
+  // remains useful for sessions where items were manually edited to have qty>1 after
+  // creation, or if the auto-split logic changes in the future.
   splitClaimItem: publicProcedure
     .input(z.object({
       token: z.string(),
@@ -691,6 +683,10 @@ export const guestRouter = createTRPCRouter({
       splitQuantity: z.number().int().min(1),
     }))
     .mutation(async ({ ctx, input }) => {
+      const { allowed } = checkRateLimit(`guest-split-item:${input.token}`, 10, 60 * 1000);
+      if (!allowed) {
+        throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: "Too many requests. Please try again shortly." });
+      }
       return withSerializableRetry(() =>
         ctx.db.$transaction(async (tx) => {
           const session = await tx.guestSplit.findUnique({

--- a/src/server/trpc/routers/guest.ts
+++ b/src/server/trpc/routers/guest.ts
@@ -59,6 +59,19 @@ async function withSerializableRetry<T>(run: () => Promise<T>): Promise<T> {
 }
 
 export const guestRouter = createTRPCRouter({
+  // Test-only: expire a session for e2e testing the expiry guards
+  ...(process.env.NODE_ENV === "test" ? {
+    _testExpireSession: publicProcedure
+      .input(z.object({ token: z.string() }))
+      .mutation(async ({ ctx, input }) => {
+        await ctx.db.guestSplit.update({
+          where: { shareToken: input.token },
+          data: { expiresAt: new Date(0) },
+        });
+        return { success: true };
+      }),
+  } : {}),
+
   deleteSplit: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
@@ -343,7 +356,11 @@ export const guestRouter = createTRPCRouter({
       const guestSplit = await ctx.db.guestSplit.create({
         data: {
           receiptId: input.receiptId,
-          receiptData: { ...input.receiptData, tip } as unknown as Prisma.InputJsonValue,
+          receiptData: {
+            ...input.receiptData,
+            tip,
+            ...(input.tipOverride != null ? { total: input.receiptData.subtotal + input.receiptData.tax + tip } : {}),
+          } as unknown as Prisma.InputJsonValue,
           items: input.items as unknown as Prisma.InputJsonValue,
           people: filteredPeople as unknown as Prisma.InputJsonValue,
           assignments: remappedAssignments as unknown as Prisma.InputJsonValue,
@@ -589,6 +606,7 @@ export const guestRouter = createTRPCRouter({
             where: { shareToken: input.token },
           });
           if (!session) throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
+          if (session.expiresAt < new Date()) throw new TRPCError({ code: "NOT_FOUND", message: "Session expired" });
           if (session.status !== "claiming") throw new TRPCError({ code: "BAD_REQUEST", message: "Session is finalized" });
 
           const people = [...(session.people as GuestSessionPerson[])];
@@ -623,6 +641,7 @@ export const guestRouter = createTRPCRouter({
             where: { shareToken: input.token },
           });
           if (!session) throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
+          if (session.expiresAt < new Date()) throw new TRPCError({ code: "NOT_FOUND", message: "Session expired" });
           if (session.status !== "claiming") throw new TRPCError({ code: "BAD_REQUEST", message: "Session is finalized" });
 
           const people = [...(session.people as GuestSessionPerson[])];
@@ -678,6 +697,7 @@ export const guestRouter = createTRPCRouter({
             where: { shareToken: input.token },
           });
           if (!session) throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
+          if (session.expiresAt < new Date()) throw new TRPCError({ code: "NOT_FOUND", message: "Session expired" });
           if (session.status !== "claiming") throw new TRPCError({ code: "BAD_REQUEST", message: "Session is finalized" });
 
           const people = session.people as GuestSessionPerson[];


### PR DESCRIPTION
## Summary (PR 2 of 4 — stacked on PR 106)
Dead code removal, backend refactoring, and consistency fixes.

- Remove unused `Copy` import
- Remove unused `newPersonName` state + `addPerson` function
- Remove unreachable `"review"` step from Step union
- Add clarifying comment on `splitClaimItem` (still useful for manual items)
- Remove redundant bounds-validation loop in `createSplit`
- Add rate limiting to 3 unguarded mutations
- Consistent error messages in `getReceiptItems`
- Replace hardcoded "Bill Split" and "Loading..." with i18n
- Extract shared Zod schemas for `receiptData`/`items`
- Extract shared expiry/cleanup helper

## Merge order
Merge PR 106 first, then this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)