### PR TITLE
fix: quality, validation, accessibility, and performance

### DIFF
--- a/messages/de/expenses.json
+++ b/messages/de/expenses.json
@@ -49,7 +49,9 @@
     "fallbackChain": "Fallback-Kette:",
     "or": "oder",
     "shareForClaiming": "Link teilen — Mitglieder wählen lassen",
-    "creatingSession": "Sitzung wird erstellt..."
+    "creatingSession": "Sitzung wird erstellt...",
+    "loadingGroup": "Gruppe wird geladen...",
+    "groupLoadError": "Gruppendaten konnten nicht geladen werden. Bitte versuchen Sie es erneut."
   },
   "receipt": {
     "hideImage": "Belegbild ausblenden",
@@ -91,7 +93,10 @@
     "saveForLater": "Für später speichern",
     "loadingItems": "Artikel werden geladen...",
     "noReceiptData": "Belegdaten konnten nicht geladen werden.",
-    "noExtractedData": "Keine extrahierten Daten verfügbar."
+    "noExtractedData": "Keine extrahierten Daten verfügbar.",
+    "validationNameRequired": "Artikelname ist erforderlich.",
+    "validationPricePositive": "Der Preis muss größer als null sein.",
+    "validationQtyPositive": "Die Menge muss eine positive ganze Zahl sein."
   },
   "splits": {
     "selectAll": "Alle auswählen",

--- a/messages/de/split.json
+++ b/messages/de/split.json
@@ -54,7 +54,10 @@
     "assignAllItems": "Alle Artikel zuordnen ({remaining} übrig)",
     "shareForClaiming": "Link teilen — Jeder wählt seine Artikel",
     "creatingSession": "Session wird erstellt...",
-    "shareHint": "Wissen Sie nicht, wer was hatte? Teilen Sie den Link und lassen Sie jede Person ihre eigenen Artikel auswählen."
+    "shareHint": "Wissen Sie nicht, wer was hatte? Teilen Sie den Link und lassen Sie jede Person ihre eigenen Artikel auswählen.",
+    "validationNameRequired": "Artikelname ist erforderlich.",
+    "validationPricePositive": "Der Preis muss größer als null sein.",
+    "validationQtyPositive": "Die Menge muss eine positive ganze Zahl sein."
   },
   "claim": {
     "loadingSession": "Session wird geladen...",

--- a/messages/en/expenses.json
+++ b/messages/en/expenses.json
@@ -49,7 +49,9 @@
     "fallbackChain": "Fallback chain:",
     "or": "or",
     "shareForClaiming": "Share Link — Let Members Claim Items",
-    "creatingSession": "Creating session..."
+    "creatingSession": "Creating session...",
+    "loadingGroup": "Loading group...",
+    "groupLoadError": "Could not load group data. Please try again."
   },
   "receipt": {
     "hideImage": "Hide Receipt Image",
@@ -91,7 +93,10 @@
     "saveForLater": "Save for Later",
     "loadingItems": "Loading items...",
     "noReceiptData": "Could not load receipt data.",
-    "noExtractedData": "No extracted data available."
+    "noExtractedData": "No extracted data available.",
+    "validationNameRequired": "Item name is required.",
+    "validationPricePositive": "Price must be greater than zero.",
+    "validationQtyPositive": "Quantity must be a positive whole number."
   },
   "splits": {
     "selectAll": "Select all",

--- a/messages/en/split.json
+++ b/messages/en/split.json
@@ -54,7 +54,10 @@
     "assignAllItems": "Assign all items ({remaining} left)",
     "shareForClaiming": "Share Link — Let Everyone Claim Their Items",
     "creatingSession": "Creating session...",
-    "shareHint": "Don't know who had what? Share the link and let each person pick their own items."
+    "shareHint": "Don't know who had what? Share the link and let each person pick their own items.",
+    "validationNameRequired": "Item name is required.",
+    "validationPricePositive": "Price must be greater than zero.",
+    "validationQtyPositive": "Quantity must be a positive whole number."
   },
   "claim": {
     "loadingSession": "Loading session...",

--- a/messages/es/expenses.json
+++ b/messages/es/expenses.json
@@ -49,7 +49,9 @@
     "fallbackChain": "Cadena de respaldo:",
     "or": "o",
     "shareForClaiming": "Compartir enlace — Dejar que los miembros reclamen artículos",
-    "creatingSession": "Creando sesión..."
+    "creatingSession": "Creando sesión...",
+    "loadingGroup": "Cargando grupo...",
+    "groupLoadError": "No se pudieron cargar los datos del grupo. Inténtelo de nuevo."
   },
   "receipt": {
     "hideImage": "Ocultar imagen del recibo",
@@ -91,7 +93,10 @@
     "saveForLater": "Guardar para después",
     "loadingItems": "Cargando artículos...",
     "noReceiptData": "No se pudieron cargar los datos del recibo.",
-    "noExtractedData": "No hay datos extraídos disponibles."
+    "noExtractedData": "No hay datos extraídos disponibles.",
+    "validationNameRequired": "El nombre del artículo es obligatorio.",
+    "validationPricePositive": "El precio debe ser mayor que cero.",
+    "validationQtyPositive": "La cantidad debe ser un número entero positivo."
   },
   "splits": {
     "selectAll": "Seleccionar todos",

--- a/messages/es/split.json
+++ b/messages/es/split.json
@@ -54,7 +54,10 @@
     "assignAllItems": "Asignar todos los artículos ({remaining} restantes)",
     "shareForClaiming": "Compartir enlace — Que cada uno elija sus artículos",
     "creatingSession": "Creando sesión...",
-    "shareHint": "¿No sabes quién pidió qué? Comparte el enlace y deja que cada persona elija sus artículos."
+    "shareHint": "¿No sabes quién pidió qué? Comparte el enlace y deja que cada persona elija sus artículos.",
+    "validationNameRequired": "El nombre del artículo es obligatorio.",
+    "validationPricePositive": "El precio debe ser mayor que cero.",
+    "validationQtyPositive": "La cantidad debe ser un número entero positivo."
   },
   "claim": {
     "loadingSession": "Cargando sesión...",

--- a/messages/fr/expenses.json
+++ b/messages/fr/expenses.json
@@ -49,7 +49,9 @@
     "fallbackChain": "Chaîne de secours :",
     "or": "ou",
     "shareForClaiming": "Partager le lien — Laissez les membres choisir",
-    "creatingSession": "Création de la session..."
+    "creatingSession": "Création de la session...",
+    "loadingGroup": "Chargement du groupe...",
+    "groupLoadError": "Impossible de charger les données du groupe. Veuillez réessayer."
   },
   "receipt": {
     "hideImage": "Masquer l'image du reçu",
@@ -91,7 +93,10 @@
     "saveForLater": "Enregistrer pour plus tard",
     "loadingItems": "Chargement des articles...",
     "noReceiptData": "Impossible de charger les données du reçu.",
-    "noExtractedData": "Aucune donnée extraite disponible."
+    "noExtractedData": "Aucune donnée extraite disponible.",
+    "validationNameRequired": "Le nom de l'article est requis.",
+    "validationPricePositive": "Le prix doit être supérieur à zéro.",
+    "validationQtyPositive": "La quantité doit être un nombre entier positif."
   },
   "splits": {
     "selectAll": "Tout sélectionner",

--- a/messages/fr/split.json
+++ b/messages/fr/split.json
@@ -54,7 +54,10 @@
     "assignAllItems": "Attribuer tous les articles ({remaining} restants)",
     "shareForClaiming": "Partager le lien — Chacun choisit ses articles",
     "creatingSession": "Création de la session...",
-    "shareHint": "Vous ne savez pas qui a pris quoi ? Partagez le lien et laissez chacun choisir ses propres articles."
+    "shareHint": "Vous ne savez pas qui a pris quoi ? Partagez le lien et laissez chacun choisir ses propres articles.",
+    "validationNameRequired": "Le nom de l'article est requis.",
+    "validationPricePositive": "Le prix doit être supérieur à zéro.",
+    "validationQtyPositive": "La quantité doit être un nombre entier positif."
   },
   "claim": {
     "loadingSession": "Chargement de la session...",

--- a/messages/ja/expenses.json
+++ b/messages/ja/expenses.json
@@ -49,7 +49,9 @@
     "fallbackChain": "フォールバックチェーン:",
     "or": "または",
     "shareForClaiming": "リンクを共有 — メンバーに選んでもらう",
-    "creatingSession": "セッションを作成中..."
+    "creatingSession": "セッションを作成中...",
+    "loadingGroup": "グループを読み込み中...",
+    "groupLoadError": "グループデータを読み込めませんでした。もう一度お試しください。"
   },
   "receipt": {
     "hideImage": "レシート画像を非表示",
@@ -91,7 +93,10 @@
     "saveForLater": "後で保存",
     "loadingItems": "品目を読み込み中...",
     "noReceiptData": "レシートデータを読み込めませんでした。",
-    "noExtractedData": "抽出されたデータがありません。"
+    "noExtractedData": "抽出されたデータがありません。",
+    "validationNameRequired": "品目名は必須です。",
+    "validationPricePositive": "価格はゼロより大きくする必要があります。",
+    "validationQtyPositive": "数量は正の整数である必要があります。"
   },
   "splits": {
     "selectAll": "すべて選択",

--- a/messages/ja/split.json
+++ b/messages/ja/split.json
@@ -54,7 +54,10 @@
     "assignAllItems": "すべての品目を割り当て（残り{remaining}）",
     "shareForClaiming": "リンクを共有 — 各自で品目を選択",
     "creatingSession": "セッションを作成中...",
-    "shareHint": "誰が何を注文したかわからない場合は、リンクを共有して各自に品目を選んでもらいましょう。"
+    "shareHint": "誰が何を注文したかわからない場合は、リンクを共有して各自に品目を選んでもらいましょう。",
+    "validationNameRequired": "品目名は必須です。",
+    "validationPricePositive": "価格はゼロより大きくする必要があります。",
+    "validationQtyPositive": "数量は正の整数である必要があります。"
   },
   "claim": {
     "loadingSession": "セッションを読み込み中...",

--- a/messages/ko/expenses.json
+++ b/messages/ko/expenses.json
@@ -49,7 +49,9 @@
     "fallbackChain": "폴백 체인:",
     "or": "또는",
     "shareForClaiming": "링크 공유 — 멤버가 직접 선택",
-    "creatingSession": "세션 생성 중..."
+    "creatingSession": "세션 생성 중...",
+    "loadingGroup": "그룹 불러오는 중...",
+    "groupLoadError": "그룹 데이터를 불러올 수 없습니다. 다시 시도해 주세요."
   },
   "receipt": {
     "hideImage": "영수증 이미지 숨기기",
@@ -91,7 +93,10 @@
     "saveForLater": "나중을 위해 저장",
     "loadingItems": "항목 로딩 중...",
     "noReceiptData": "영수증 데이터를 불러올 수 없습니다.",
-    "noExtractedData": "추출된 데이터가 없습니다."
+    "noExtractedData": "추출된 데이터가 없습니다.",
+    "validationNameRequired": "항목 이름은 필수입니다.",
+    "validationPricePositive": "가격은 0보다 커야 합니다.",
+    "validationQtyPositive": "수량은 양의 정수여야 합니다."
   },
   "splits": {
     "selectAll": "전체 선택",

--- a/messages/ko/split.json
+++ b/messages/ko/split.json
@@ -54,7 +54,10 @@
     "assignAllItems": "모든 항목 배정 ({remaining}개 남음)",
     "shareForClaiming": "링크 공유 — 각자 항목 선택하기",
     "creatingSession": "세션 생성 중...",
-    "shareHint": "누가 뭘 주문했는지 모르세요? 링크를 공유하고 각자 자신의 항목을 선택하게 하세요."
+    "shareHint": "누가 뭘 주문했는지 모르세요? 링크를 공유하고 각자 자신의 항목을 선택하게 하세요.",
+    "validationNameRequired": "항목 이름은 필수입니다.",
+    "validationPricePositive": "가격은 0보다 커야 합니다.",
+    "validationQtyPositive": "수량은 양의 정수여야 합니다."
   },
   "claim": {
     "loadingSession": "세션 로딩 중...",

--- a/messages/pt-BR/expenses.json
+++ b/messages/pt-BR/expenses.json
@@ -49,7 +49,9 @@
     "fallbackChain": "Cadeia de fallback:",
     "or": "ou",
     "shareForClaiming": "Compartilhar link — Deixe os membros escolherem",
-    "creatingSession": "Criando sessão..."
+    "creatingSession": "Criando sessão...",
+    "loadingGroup": "Carregando grupo...",
+    "groupLoadError": "Não foi possível carregar os dados do grupo. Tente novamente."
   },
   "receipt": {
     "hideImage": "Ocultar imagem do recibo",
@@ -91,7 +93,10 @@
     "saveForLater": "Salvar para depois",
     "loadingItems": "Carregando itens...",
     "noReceiptData": "Não foi possível carregar os dados do recibo.",
-    "noExtractedData": "Nenhum dado extraído disponível."
+    "noExtractedData": "Nenhum dado extraído disponível.",
+    "validationNameRequired": "O nome do item é obrigatório.",
+    "validationPricePositive": "O preço deve ser maior que zero.",
+    "validationQtyPositive": "A quantidade deve ser um número inteiro positivo."
   },
   "splits": {
     "selectAll": "Selecionar todos",

--- a/messages/pt-BR/split.json
+++ b/messages/pt-BR/split.json
@@ -54,7 +54,10 @@
     "assignAllItems": "Atribuir todos os itens ({remaining} restantes)",
     "shareForClaiming": "Compartilhar link — Cada um escolhe seus itens",
     "creatingSession": "Criando sessão...",
-    "shareHint": "Não sabe quem pediu o quê? Compartilhe o link e deixe cada pessoa escolher seus próprios itens."
+    "shareHint": "Não sabe quem pediu o quê? Compartilhe o link e deixe cada pessoa escolher seus próprios itens.",
+    "validationNameRequired": "O nome do item é obrigatório.",
+    "validationPricePositive": "O preço deve ser maior que zero.",
+    "validationQtyPositive": "A quantidade deve ser um número inteiro positivo."
   },
   "claim": {
     "loadingSession": "Carregando sessão...",

--- a/messages/sv/expenses.json
+++ b/messages/sv/expenses.json
@@ -49,7 +49,9 @@
     "fallbackChain": "Reservkedja:",
     "or": "eller",
     "shareForClaiming": "Dela länk — Låt medlemmar välja artiklar",
-    "creatingSession": "Skapar session..."
+    "creatingSession": "Skapar session...",
+    "loadingGroup": "Laddar grupp...",
+    "groupLoadError": "Kunde inte ladda gruppdata. Försök igen."
   },
   "receipt": {
     "hideImage": "Dölj kvittobild",
@@ -91,7 +93,10 @@
     "saveForLater": "Spara till senare",
     "loadingItems": "Laddar artiklar...",
     "noReceiptData": "Kunde inte ladda kvittodata.",
-    "noExtractedData": "Inga extraherade data tillgängliga."
+    "noExtractedData": "Inga extraherade data tillgängliga.",
+    "validationNameRequired": "Artikelnamn krävs.",
+    "validationPricePositive": "Priset måste vara större än noll.",
+    "validationQtyPositive": "Antal måste vara ett positivt heltal."
   },
   "splits": {
     "selectAll": "Välj alla",

--- a/messages/sv/split.json
+++ b/messages/sv/split.json
@@ -54,7 +54,10 @@
     "assignAllItems": "Tilldela alla artiklar ({remaining} kvar)",
     "shareForClaiming": "Dela länk — Låt alla välja sina artiklar",
     "creatingSession": "Skapar session...",
-    "shareHint": "Vet du inte vem som hade vad? Dela länken och låt varje person välja sina egna artiklar."
+    "shareHint": "Vet du inte vem som hade vad? Dela länken och låt varje person välja sina egna artiklar.",
+    "validationNameRequired": "Artikelnamn krävs.",
+    "validationPricePositive": "Priset måste vara större än noll.",
+    "validationQtyPositive": "Antal måste vara ett positivt heltal."
   },
   "claim": {
     "loadingSession": "Laddar session...",

--- a/messages/zh-CN/expenses.json
+++ b/messages/zh-CN/expenses.json
@@ -49,7 +49,9 @@
     "fallbackChain": "备用链：",
     "or": "或",
     "shareForClaiming": "分享链接 — 让成员自行选择",
-    "creatingSession": "正在创建会话..."
+    "creatingSession": "正在创建会话...",
+    "loadingGroup": "正在加载群组...",
+    "groupLoadError": "无法加载群组数据。请重试。"
   },
   "receipt": {
     "hideImage": "隐藏小票图片",
@@ -91,7 +93,10 @@
     "saveForLater": "稍后保存",
     "loadingItems": "正在加载项目...",
     "noReceiptData": "无法加载小票数据。",
-    "noExtractedData": "没有可用的提取数据。"
+    "noExtractedData": "没有可用的提取数据。",
+    "validationNameRequired": "请输入项目名称。",
+    "validationPricePositive": "价格必须大于零。",
+    "validationQtyPositive": "数量必须是正整数。"
   },
   "splits": {
     "selectAll": "全选",

--- a/messages/zh-CN/split.json
+++ b/messages/zh-CN/split.json
@@ -54,7 +54,10 @@
     "assignAllItems": "分配所有项目（剩余 {remaining}）",
     "shareForClaiming": "分享链接 — 让每个人选择自己的项目",
     "creatingSession": "正在创建会话...",
-    "shareHint": "不知道谁点了什么？分享链接，让每个人自己选择项目。"
+    "shareHint": "不知道谁点了什么？分享链接，让每个人自己选择项目。",
+    "validationNameRequired": "请输入项目名称。",
+    "validationPricePositive": "价格必须大于零。",
+    "validationQtyPositive": "数量必须是正整数。"
   },
   "claim": {
     "loadingSession": "正在加载会话...",

--- a/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/scan/page.tsx
@@ -169,6 +169,35 @@ function ScanReceiptContent({
     providerInfo.data?.configuredProviders?.join(" -> ") ?? "loading...";
   const activeProvider = providerInfo.data?.activeProvider ?? "checking...";
 
+  // Loading state for group data (Finding #22)
+  if (group.isLoading) {
+    return (
+      <div className="mx-auto max-w-lg flex flex-col items-center gap-4 py-20">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <p className="text-muted-foreground">{t("loadingGroup")}</p>
+      </div>
+    );
+  }
+
+  // Error state for group data (Finding #22)
+  if (group.error) {
+    return (
+      <div className="mx-auto max-w-lg space-y-6">
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="icon" nativeButton={false} render={<Link href={`/groups/${groupId}`} />}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <h1 className="text-2xl font-bold">{t("title")}</h1>
+        </div>
+        <Card className="border-destructive/50">
+          <CardContent className="py-6">
+            <p className="text-destructive">{t("groupLoadError")}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
   return (
     <div className="mx-auto max-w-lg space-y-6">
       <div className="flex items-center gap-2">

--- a/src/app/[locale]/(app)/splits/page.tsx
+++ b/src/app/[locale]/(app)/splits/page.tsx
@@ -29,6 +29,7 @@ export default function SplitsPage() {
       utils.guest.mySplits.invalidate();
       toast.success(t("deleted"));
     },
+    onError: (err) => toast.error(err.message),
   });
 
   const splits = data?.pages.flatMap((page) => page.splits) ?? [];

--- a/src/app/[locale]/split/[token]/claim/page.tsx
+++ b/src/app/[locale]/split/[token]/claim/page.tsx
@@ -672,6 +672,7 @@ export default function ClaimPage({
                       onChange={(e) => setEditingName(e.target.value)}
                       className="h-7 text-sm"
                       autoFocus
+                      aria-label={t("editName")}
                       data-testid={`edit-name-input-${idx}`}
                     />
                     <Button type="submit" size="sm" variant="ghost" className="h-7 px-2" disabled={editPersonName.isPending}>
@@ -875,6 +876,7 @@ export default function ClaimPage({
                             value={splitQty}
                             onChange={(e) => setSplitQty(e.target.value)}
                             className="w-16 h-7 text-xs"
+                            aria-label={t("splitOff")}
                             data-testid={`split-qty-input-${idx}`}
                           />
                           <span className="text-xs text-muted-foreground">{t("splitOfTotal", { total: item.quantity })}</span>

--- a/src/app/[locale]/split/page.tsx
+++ b/src/app/[locale]/split/page.tsx
@@ -188,6 +188,10 @@ export default function GuestSplitPage() {
   }
 
   // Assignment
+  // Note (Finding #29): toggleAssignment and assignAllToEveryone are intentionally
+  // duplicated from item-assignment.tsx. This component uses Record<number, Set<number>>
+  // (index-based) while item-assignment uses Record<string, Set<string>> (id-based).
+  // The different key types make a shared abstraction more complex than the duplication.
   function toggleAssignment(itemIdx: number, personIdx: number) {
     setAssignments((prev) => {
       const next = { ...prev };
@@ -227,11 +231,15 @@ export default function GuestSplitPage() {
 
   function saveEdit() {
     if (editingItem === null) return;
+    const trimmedName = editValues.name.trim();
+    if (!trimmedName) { toast.error(t("assign.validationNameRequired")); return; }
     const totalPrice = parseToCents(editValues.totalPrice);
-    const quantity = parseInt(editValues.quantity) || 1;
+    if (totalPrice <= 0) { toast.error(t("assign.validationPricePositive")); return; }
+    const quantity = parseInt(editValues.quantity);
+    if (!Number.isInteger(quantity) || quantity < 1) { toast.error(t("assign.validationQtyPositive")); return; }
     setItems((prev) => prev.map((item, i) =>
       i === editingItem
-        ? { name: editValues.name, quantity, unitPrice: Math.round(totalPrice / quantity), totalPrice }
+        ? { name: trimmedName, quantity, unitPrice: Math.round(totalPrice / quantity), totalPrice }
         : item
     ));
     setEditingItem(null);
@@ -308,7 +316,8 @@ export default function GuestSplitPage() {
   }
 
   // Calculate totals
-  const tip = tipOverride !== "" ? Math.round(parseFloat(tipOverride) * 100) : (extracted?.tip ?? 0);
+  const parsedTip = parseFloat(tipOverride);
+  const tip = tipOverride !== "" && isFinite(parsedTip) ? Math.round(parsedTip * 100) : (extracted?.tip ?? 0);
   const currency = extracted?.currency ?? "USD";
 
   const getPerPersonTotals = useCallback(() => {
@@ -366,7 +375,7 @@ export default function GuestSplitPage() {
         people: validPeople.map((n) => ({ name: n })),
         assignments: assignmentList,
         paidByIndex: remappedPaidBy,
-        tipOverride: tipOverride !== "" ? Math.round(parseFloat(tipOverride) * 100) : undefined,
+        tipOverride: tipOverride !== "" && isFinite(parseFloat(tipOverride)) ? Math.round(parseFloat(tipOverride) * 100) : undefined,
       });
       router.push(`/split/${result.shareToken}`);
     } catch (err) {

--- a/src/components/receipts/item-assignment.tsx
+++ b/src/components/receipts/item-assignment.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { trpc } from "@/lib/trpc";
 import { formatCents, centsToDecimal, parseToCents } from "@/lib/money";
+import { calculateSplitTotals } from "@/lib/split-calculator";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -11,6 +12,7 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Check, Users, Pencil, Trash2, Plus, Image as ImageIcon, Scissors, Bookmark } from "lucide-react";
+import { toast } from "sonner";
 
 type Member = { id: string; name: string | null };
 
@@ -148,8 +150,13 @@ export function ItemAssignment({
     return <p className="text-destructive">{t("noExtractedData")}</p>;
   }
 
-  const tip = tipOverride !== "" ? Math.round(parseFloat(tipOverride) * 100) : extracted.tip;
+  const parsedTip = parseFloat(tipOverride);
+  const tip = tipOverride !== "" && isFinite(parsedTip) ? Math.round(parsedTip * 100) : extracted.tip;
 
+  // Note (Finding #29): toggleAssignment and assignAllToEveryone are intentionally
+  // duplicated from split/page.tsx. This component uses Record<string, Set<string>>
+  // (id-based) while split/page uses Record<number, Set<number>> (index-based).
+  // The different key types make a shared abstraction more complex than the duplication.
   function toggleAssignment(itemId: string, userId: string) {
     setAssignments((prev) => {
       const next = { ...prev };
@@ -182,19 +189,22 @@ export function ItemAssignment({
   }
 
   function saveEdit(itemId: string) {
+    const trimmedName = editValues.name.trim();
+    if (!trimmedName) { toast.error(t("validationNameRequired")); return; }
     const totalPrice = parseToCents(editValues.totalPrice);
-    const quantity = parseInt(editValues.quantity) || 1;
+    if (totalPrice <= 0) { toast.error(t("validationPricePositive")); return; }
+    const quantity = parseInt(editValues.quantity);
+    if (!Number.isInteger(quantity) || quantity < 1) { toast.error(t("validationQtyPositive")); return; }
     updateItem.mutate({
       itemId,
-      name: editValues.name,
+      name: trimmedName,
       quantity,
       totalPrice,
       unitPrice: Math.round(totalPrice / quantity),
     });
   }
 
-  function handleAddItem(e: React.FormEvent) {
-    e.preventDefault();
+  function handleAddItem() {
     const totalPrice = parseToCents(newItem.totalPrice);
     const quantity = parseInt(newItem.quantity) || 1;
     if (!newItem.name || totalPrice <= 0) return;
@@ -207,51 +217,58 @@ export function ItemAssignment({
     });
   }
 
-  // Calculate per-person totals
-  function getPerPersonTotals(): Map<string, number> {
-    const userSubtotals = new Map<string, number>();
+  // Calculate per-person totals using shared calculateSplitTotals (Finding #30).
+  // Memoized to avoid recomputation on every render (Finding #36).
+  const perPersonTotals = useMemo(() => {
+    // Build member-id -> index mapping for calculateSplitTotals
+    const memberIdToIndex = new Map<string, number>();
+    members.forEach((m, i) => memberIdToIndex.set(m.id, i));
 
-    for (const item of items) {
-      const assigned = assignments[item.id];
-      if (!assigned || assigned.size === 0) continue;
+    const assignmentList = Object.entries(assignments)
+      .filter(([, userIds]) => userIds.size > 0)
+      .map(([receiptItemId, userIds]) => {
+        const itemIdx = items.findIndex((it) => it.id === receiptItemId);
+        return {
+          itemIndex: itemIdx,
+          personIndices: Array.from(userIds)
+            .map((uid) => memberIdToIndex.get(uid))
+            .filter((idx): idx is number => idx !== undefined),
+        };
+      })
+      .filter((a) => a.itemIndex >= 0 && a.personIndices.length > 0);
 
-      const perPerson = Math.floor(item.totalPrice / assigned.size);
-      const remainder = item.totalPrice - perPerson * assigned.size;
-      const userIds = Array.from(assigned);
+    const results = calculateSplitTotals({
+      items,
+      assignments: assignmentList,
+      tax: extracted!.tax,
+      tip,
+      peopleCount: members.length,
+    });
 
-      for (let i = 0; i < userIds.length; i++) {
-        const amount = perPerson + (i < remainder ? 1 : 0);
-        userSubtotals.set(userIds[i], (userSubtotals.get(userIds[i]) ?? 0) + amount);
-      }
+    // Map back from person indices to member IDs
+    const totals = new Map<string, number>();
+    for (const r of results) {
+      const member = members[r.personIndex];
+      if (member) totals.set(member.id, r.total);
     }
-
-    const actualSubtotal = Array.from(userSubtotals.values()).reduce((a, b) => a + b, 0);
-    const totalAmount = actualSubtotal + extracted!.tax + tip;
-
-    const userTotals = new Map<string, number>();
-    let allocated = 0;
-    const entries = Array.from(userSubtotals.entries());
-
-    for (let i = 0; i < entries.length; i++) {
-      const [userId, itemTotal] = entries[i];
-      if (i === entries.length - 1) {
-        userTotals.set(userId, totalAmount - allocated);
-      } else {
-        const proportion = actualSubtotal > 0 ? itemTotal / actualSubtotal : 0;
-        const userTax = Math.round(extracted!.tax * proportion);
-        const userTip = Math.round(tip * proportion);
-        const total = itemTotal + userTax + userTip;
-        userTotals.set(userId, total);
-        allocated += total;
-      }
-    }
-
-    return userTotals;
-  }
-
-  const perPersonTotals = getPerPersonTotals();
+    return totals;
+  }, [items, assignments, members, extracted, tip]);
   const assignedItemCount = Object.values(assignments).filter((s) => s.size > 0).length;
   const allAssigned = items.length > 0 && assignedItemCount === items.length;
+
+  // Precompute member initials to avoid recalculation every render (Finding #37)
+  const memberInitials = useMemo(
+    () =>
+      new Map(
+        members.map((m) => [
+          m.id,
+          m.name
+            ? m.name.split(" ").map((n) => n[0]).join("").toUpperCase().slice(0, 2)
+            : "?",
+        ])
+      ),
+    [members]
+  );
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -262,7 +279,7 @@ export function ItemAssignment({
       receiptId,
       title,
       paidById,
-      tipOverride: tipOverride !== "" ? Math.round(parseFloat(tipOverride) * 100) : undefined,
+      tipOverride: tipOverride !== "" && isFinite(parseFloat(tipOverride)) ? Math.round(parseFloat(tipOverride) * 100) : undefined,
       assignments: Object.entries(assignments)
         .filter(([, userIds]) => userIds.size > 0)
         .map(([receiptItemId, userIds]) => ({
@@ -483,7 +500,7 @@ export function ItemAssignment({
       {addingItem && (
         <Card className="border-primary/50" data-testid="add-item-form">
           <CardContent className="py-3">
-            <form onSubmit={handleAddItem} className="space-y-2">
+            <div className="space-y-2">
               <div className="flex gap-2">
                 <Input
                   placeholder={t("itemNamePlaceholder")}
@@ -511,14 +528,14 @@ export function ItemAssignment({
                 />
               </div>
               <div className="flex gap-2">
-                <Button type="submit" size="sm" disabled={addItem.isPending}>
+                <Button type="button" size="sm" disabled={addItem.isPending} onClick={handleAddItem}>
                   {addItem.isPending ? t("adding") : t("add")}
                 </Button>
                 <Button type="button" variant="ghost" size="sm" onClick={() => setAddingItem(false)}>
                   {t("cancel")}
                 </Button>
               </div>
-            </form>
+            </div>
           </CardContent>
         </Card>
       )}
@@ -655,14 +672,6 @@ export function ItemAssignment({
                 <div className="flex flex-wrap gap-1.5">
                   {members.map((m) => {
                     const isAssigned = assigned.has(m.id);
-                    const initials = m.name
-                      ? m.name
-                          .split(" ")
-                          .map((n) => n[0])
-                          .join("")
-                          .toUpperCase()
-                          .slice(0, 2)
-                      : "?";
                     return (
                       <button
                         key={m.id}
@@ -677,7 +686,7 @@ export function ItemAssignment({
                       >
                         <Avatar className="h-4 w-4">
                           <AvatarFallback className="text-[8px]">
-                            {initials}
+                            {memberInitials.get(m.id) ?? "?"}
                           </AvatarFallback>
                         </Avatar>
                         {m.name?.split(" ")[0] ?? "?"}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,13 +1,19 @@
 export async function register() {
   // Only run on the server (not during build or in edge runtime)
   if (process.env.NEXT_RUNTIME === "nodejs") {
-    const { getBuildInfo } = await import("@/server/lib/build-info");
-    const { version, commitSha } = getBuildInfo();
+    try {
+      const { getBuildInfo } = await import("@/server/lib/build-info");
+      const { version, commitSha } = getBuildInfo();
 
-    const { logger } = await import("@/server/lib/logger");
-    logger.info("app.startup", { version, commitSha });
+      const { logger } = await import("@/server/lib/logger");
+      logger.info("app.startup", { version, commitSha });
 
-    const { startPoller } = await import("@/server/lib/auth-health-poller");
-    startPoller();
+      const { startPoller } = await import("@/server/lib/auth-health-poller");
+      startPoller();
+    } catch (error) {
+      // Isolate startup failures so the app can still boot (Finding #23).
+      // Use console.error as logger may not be available if the import itself failed.
+      console.error("app.startup.failed", error instanceof Error ? error.message : error);
+    }
   }
 }

--- a/src/server/lib/build-info.ts
+++ b/src/server/lib/build-info.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { logger } from "./logger";
 
 interface BuildInfo {
   version: string;
@@ -15,7 +16,11 @@ export function getBuildInfo(): BuildInfo {
   try {
     const pkg = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), "package.json"), "utf-8"));
     version = pkg.version;
-  } catch {}
+  } catch (error) {
+    logger.warn("build-info.version.failed", {
+      error: error instanceof Error ? error.message : "Unknown",
+    });
+  }
 
   let commitSha = "unknown";
   try {
@@ -25,7 +30,11 @@ export function getBuildInfo(): BuildInfo {
       try {
         const { execFileSync } = require("child_process");
         commitSha = execFileSync("git", ["rev-parse", "--short", "HEAD"], { encoding: "utf-8" }).trim();
-      } catch {}
+      } catch (error) {
+        logger.warn("build-info.commitSha.failed", {
+          error: error instanceof Error ? error.message : "Unknown",
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary (PR 3 of 4 — stacked on PR 107)
Quality improvements, validation guards, accessibility fixes, and performance optimizations.

**Validation & Quality:**
- Replace nested `<form>` with `<div>` (invalid HTML)
- Add validation guards to `saveEdit` (non-empty name, positive values)
- Add `isFinite` guard to `tipOverride` `parseFloat` (prevent NaN)
- Add `onError` toast to `deleteSplit` mutation
- Add loading/error states for group query in scan page
- Wrap instrumentation startup in try-catch
- Replace empty catch blocks in build-info with `logger.warn`

**Accessibility:**
- Add `aria-label` to rename input in claim page
- Add `aria-label` to split-qty input in claim page

**Performance & Duplication:**
- Add comments documenting intentional duplication
- Replace custom `getPerPersonTotals` with shared `calculateSplitTotals`
- Memoize per-person totals with `useMemo`
- Precompute member initials outside render loop

## Merge order
Merge PR 106 → PR 107 → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)