### PR TITLE
chore: add data-testids to settings, balances, and dashboard

### DIFF
--- a/src/app/[locale]/(app)/dashboard/page.tsx
+++ b/src/app/[locale]/(app)/dashboard/page.tsx
@@ -223,7 +223,7 @@ export default function DashboardPage() {
         </Card>
 
         {/* People you owe */}
-        <Card>
+        <Card data-testid="you-owe-section">
           <CardHeader className="pb-2">
             <CardTitle className="flex items-center gap-2 text-sm font-medium">
               <ArrowUpRight className="h-4 w-4 text-red-600 dark:text-red-400" />

--- a/src/app/[locale]/(app)/groups/[groupId]/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/page.tsx
@@ -196,7 +196,7 @@ export default function GroupDetailPage({
         <Card>
           <CardHeader className="pb-3">
             <div className="flex items-center justify-between">
-              <CardTitle className="text-base">Balances</CardTitle>
+              <CardTitle className="text-base" data-testid="balances-title">Balances</CardTitle>
               <Button
                 variant="outline"
                 size="sm"

--- a/src/app/[locale]/(app)/settings/page.tsx
+++ b/src/app/[locale]/(app)/settings/page.tsx
@@ -78,7 +78,7 @@ export default function SettingsPage() {
                 required
               />
             </div>
-            <Button type="submit" disabled={updateProfile.isPending}>
+            <Button type="submit" disabled={updateProfile.isPending} data-testid="save-profile-btn">
               {updateProfile.isPending ? t("profile.saving") : t("profile.save")}
             </Button>
             {updateProfile.isSuccess && (


### PR DESCRIPTION
## Summary
Adds data-testid attributes to three components for e2e test reliability.

- `save-profile-btn` — settings page save button
- `balances-title` — group page balances card title
- `you-owe-section` — dashboard "people you owe" card

No functional changes. Enables downstream PRs to use testid-based selectors instead of getByText/getByRole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)