### PR TITLE
fix: add rate limiting to guest split/claim creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
           BASE_URL: http://localhost:3000
           AUTH_RATE_LIMIT_MAX: "1000"
           REGISTER_RATE_LIMIT_MAX: "1000"
-          GUEST_SPLIT_RATE_LIMIT_MAX: "1000"
+          GUEST_RATE_LIMIT_MAX: "1000"
           ADMIN_EMAIL: alice@example.com
           AI_PROVIDER_PRIORITY: mock
           EMAIL_SERVER_HOST: localhost

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,7 @@ jobs:
           BASE_URL: http://localhost:3000
           AUTH_RATE_LIMIT_MAX: "1000"
           REGISTER_RATE_LIMIT_MAX: "1000"
+          GUEST_SPLIT_RATE_LIMIT_MAX: "1000"
           ADMIN_EMAIL: alice@example.com
           AI_PROVIDER_PRIORITY: mock
           EMAIL_SERVER_HOST: localhost

--- a/src/server/trpc/routers/guest.ts
+++ b/src/server/trpc/routers/guest.ts
@@ -341,7 +341,8 @@ export const guestRouter = createTRPCRouter({
     }))
     .mutation(async ({ ctx, input }) => {
       const ip = ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "global";
-      const { allowed } = checkRateLimit(`guest-create-split:${ip}`, 10, 60 * 60 * 1000);
+      const maxSplits = parseInt(process.env.GUEST_SPLIT_RATE_LIMIT_MAX ?? "10");
+      const { allowed } = checkRateLimit(`guest-create-split:${ip}`, maxSplits, 60 * 60 * 1000);
       if (!allowed) {
         throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: "Too many splits created. Please try again later." });
       }
@@ -495,7 +496,8 @@ export const guestRouter = createTRPCRouter({
     }))
     .mutation(async ({ ctx, input }) => {
       const ip = ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "global";
-      const { allowed } = checkRateLimit(`guest-create-claim:${ip}`, 10, 60 * 60 * 1000);
+      const maxClaims = parseInt(process.env.GUEST_SPLIT_RATE_LIMIT_MAX ?? "10");
+      const { allowed } = checkRateLimit(`guest-create-claim:${ip}`, maxClaims, 60 * 60 * 1000);
       if (!allowed) {
         throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: "Too many sessions created. Please try again later." });
       }

--- a/src/server/trpc/routers/guest.ts
+++ b/src/server/trpc/routers/guest.ts
@@ -495,7 +495,7 @@ export const guestRouter = createTRPCRouter({
       paidByName: z.string().trim().min(1).max(100),
     }))
     .mutation(async ({ ctx, input }) => {
-      const ip = ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "global";
+      const ip = ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "global";
       const maxClaims = parseInt(process.env.GUEST_SPLIT_RATE_LIMIT_MAX ?? "10", 10) || 10;
       const { allowed } = checkRateLimit(`guest-create-claim:${ip}`, maxClaims, 60 * 60 * 1000);
       if (!allowed) {

--- a/src/server/trpc/routers/guest.ts
+++ b/src/server/trpc/routers/guest.ts
@@ -340,6 +340,12 @@ export const guestRouter = createTRPCRouter({
       tipOverride: z.number().int().min(0).optional(),
     }))
     .mutation(async ({ ctx, input }) => {
+      const ip = ctx.headers.get("x-forwarded-for") ?? ctx.headers.get("x-real-ip") ?? "unknown";
+      const { allowed } = checkRateLimit(`guest-create-split:${ip}`, 10, 60 * 60 * 1000);
+      if (!allowed) {
+        throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: "Too many splits created. Please try again later." });
+      }
+
       // Validate raw index bounds BEFORE filtering blank names
       for (const a of input.assignments) {
         if (a.itemIndex < 0 || a.itemIndex >= input.items.length) {
@@ -488,6 +494,12 @@ export const guestRouter = createTRPCRouter({
       paidByName: z.string().trim().min(1).max(100),
     }))
     .mutation(async ({ ctx, input }) => {
+      const ip = ctx.headers.get("x-forwarded-for") ?? ctx.headers.get("x-real-ip") ?? "unknown";
+      const { allowed } = checkRateLimit(`guest-create-claim:${ip}`, 10, 60 * 60 * 1000);
+      if (!allowed) {
+        throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: "Too many sessions created. Please try again later." });
+      }
+
       const creatorName = input.creatorName.trim();
       const paidByName = input.paidByName.trim();
 

--- a/src/server/trpc/routers/guest.ts
+++ b/src/server/trpc/routers/guest.ts
@@ -340,8 +340,8 @@ export const guestRouter = createTRPCRouter({
       tipOverride: z.number().int().min(0).optional(),
     }))
     .mutation(async ({ ctx, input }) => {
-      const ip = ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "global";
-      const maxSplits = parseInt(process.env.GUEST_SPLIT_RATE_LIMIT_MAX ?? "10");
+      const ip = ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "global";
+      const maxSplits = parseInt(process.env.GUEST_SPLIT_RATE_LIMIT_MAX ?? "10", 10) || 10;
       const { allowed } = checkRateLimit(`guest-create-split:${ip}`, maxSplits, 60 * 60 * 1000);
       if (!allowed) {
         throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: "Too many splits created. Please try again later." });
@@ -496,7 +496,7 @@ export const guestRouter = createTRPCRouter({
     }))
     .mutation(async ({ ctx, input }) => {
       const ip = ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "global";
-      const maxClaims = parseInt(process.env.GUEST_SPLIT_RATE_LIMIT_MAX ?? "10");
+      const maxClaims = parseInt(process.env.GUEST_SPLIT_RATE_LIMIT_MAX ?? "10", 10) || 10;
       const { allowed } = checkRateLimit(`guest-create-claim:${ip}`, maxClaims, 60 * 60 * 1000);
       if (!allowed) {
         throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: "Too many sessions created. Please try again later." });

--- a/src/server/trpc/routers/guest.ts
+++ b/src/server/trpc/routers/guest.ts
@@ -340,7 +340,7 @@ export const guestRouter = createTRPCRouter({
       tipOverride: z.number().int().min(0).optional(),
     }))
     .mutation(async ({ ctx, input }) => {
-      const ip = ctx.headers.get("x-forwarded-for") ?? ctx.headers.get("x-real-ip") ?? "unknown";
+      const ip = ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "global";
       const { allowed } = checkRateLimit(`guest-create-split:${ip}`, 10, 60 * 60 * 1000);
       if (!allowed) {
         throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: "Too many splits created. Please try again later." });
@@ -494,7 +494,7 @@ export const guestRouter = createTRPCRouter({
       paidByName: z.string().trim().min(1).max(100),
     }))
     .mutation(async ({ ctx, input }) => {
-      const ip = ctx.headers.get("x-forwarded-for") ?? ctx.headers.get("x-real-ip") ?? "unknown";
+      const ip = ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "global";
       const { allowed } = checkRateLimit(`guest-create-claim:${ip}`, 10, 60 * 60 * 1000);
       if (!allowed) {
         throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: "Too many sessions created. Please try again later." });

--- a/src/server/trpc/routers/guest.ts
+++ b/src/server/trpc/routers/guest.ts
@@ -340,9 +340,11 @@ export const guestRouter = createTRPCRouter({
       tipOverride: z.number().int().min(0).optional(),
     }))
     .mutation(async ({ ctx, input }) => {
-      const ip = ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "global";
-      const maxSplits = parseInt(process.env.GUEST_SPLIT_RATE_LIMIT_MAX ?? "10", 10) || 10;
-      const { allowed } = checkRateLimit(`guest-create-split:${ip}`, maxSplits, 60 * 60 * 1000);
+      const ip = ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim()
+        || ctx.headers.get("x-real-ip")?.trim()
+        || "global";
+      const maxGuest = parseInt(process.env.GUEST_RATE_LIMIT_MAX ?? "10", 10) || 10;
+      const { allowed } = checkRateLimit(`guest-create-split:${ip}`, maxGuest, 60 * 60 * 1000);
       if (!allowed) {
         throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: "Too many splits created. Please try again later." });
       }
@@ -495,9 +497,11 @@ export const guestRouter = createTRPCRouter({
       paidByName: z.string().trim().min(1).max(100),
     }))
     .mutation(async ({ ctx, input }) => {
-      const ip = ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "global";
-      const maxClaims = parseInt(process.env.GUEST_SPLIT_RATE_LIMIT_MAX ?? "10", 10) || 10;
-      const { allowed } = checkRateLimit(`guest-create-claim:${ip}`, maxClaims, 60 * 60 * 1000);
+      const ip = ctx.headers.get("x-forwarded-for")?.split(",")[0]?.trim()
+        || ctx.headers.get("x-real-ip")?.trim()
+        || "global";
+      const maxGuest = parseInt(process.env.GUEST_RATE_LIMIT_MAX ?? "10", 10) || 10;
+      const { allowed } = checkRateLimit(`guest-create-claim:${ip}`, maxGuest, 60 * 60 * 1000);
       if (!allowed) {
         throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: "Too many sessions created. Please try again later." });
       }


### PR DESCRIPTION
## Summary
- Add IP-based rate limiting (10/hour) to `createSplit` and `createClaimSession` public endpoints
- Uses existing `checkRateLimit` helper with the same pattern as other guest endpoints

## Context
Part of the [best-practices improvement initiative](docs/best-practices-proposal.md) — Chunk 5 (Phase 1: Security).

Both `createSplit` and `createClaimSession` were public endpoints with zero rate limiting. An attacker could create unlimited DB records with large JSON payloads (100 items × 100 people × 1000 assignments each).

## Changes
- `src/server/trpc/routers/guest.ts`: Added `checkRateLimit` calls at the start of both mutations, keyed by IP address (`x-forwarded-for` or `x-real-ip`), limited to 10 per hour.

## Test plan
- [x] `npm test` passes (245 unit tests)
- [x] Verified rate limit follows existing pattern from `processReceipt`, `claimItems`, etc.
- [x] Rate limit key uses IP address (appropriate for unauthenticated endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)