### PR TITLE
fix: sign admin impersonation cookie with HMAC

### DIFF
--- a/src/app/api/admin/impersonate/route.ts
+++ b/src/app/api/admin/impersonate/route.ts
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 import { auth } from "@/server/auth";
 import { db } from "@/server/db";
 import { logAdminAction } from "@/server/trpc/routers/admin";
+import { signPayload } from "@/server/lib/signed-cookie";
 
 const COOKIE_NAME = "sharetab-impersonate";
 
@@ -41,7 +42,6 @@ export async function POST(req: Request) {
     return Response.json({ error: "User not found" }, { status: 404 });
   }
 
-  // Store impersonation data as JSON in a secure cookie
   const impersonationData = JSON.stringify({
     adminId: session.user.id,
     adminEmail: session.user.email,
@@ -52,7 +52,7 @@ export async function POST(req: Request) {
   });
 
   const cookieStore = await cookies();
-  cookieStore.set(COOKIE_NAME, impersonationData, {
+  cookieStore.set(COOKIE_NAME, signPayload(impersonationData), {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",

--- a/src/server/lib/signed-cookie.test.ts
+++ b/src/server/lib/signed-cookie.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { signPayload, verifyAndParse } from "./signed-cookie";
+
+beforeAll(() => {
+  process.env.AUTH_SECRET = "test-secret-for-signing";
+});
+
+describe("signPayload / verifyAndParse", () => {
+  it("round-trips valid JSON", () => {
+    const payload = JSON.stringify({ adminId: "abc", targetId: "xyz" });
+    const signed = signPayload(payload);
+    const parsed = verifyAndParse<{ adminId: string; targetId: string }>(signed);
+    expect(parsed).toEqual({ adminId: "abc", targetId: "xyz" });
+  });
+
+  it("rejects tampered payload", () => {
+    const signed = signPayload(JSON.stringify({ adminId: "abc" }));
+    const tampered = signed.replace("abc", "xyz");
+    expect(verifyAndParse(tampered)).toBeNull();
+  });
+
+  it("rejects tampered signature", () => {
+    const signed = signPayload(JSON.stringify({ adminId: "abc" }));
+    const parts = signed.split(".");
+    parts[parts.length - 1] = "0".repeat(64);
+    expect(verifyAndParse(parts.join("."))).toBeNull();
+  });
+
+  it("rejects unsigned input (no dot separator)", () => {
+    expect(verifyAndParse('{"adminId":"abc"}')).toBeNull();
+  });
+
+  it("rejects malformed JSON with valid-looking signature", () => {
+    const signed = signPayload("not-valid-json");
+    expect(verifyAndParse(signed)).toBeNull();
+  });
+
+  it("rejects empty string", () => {
+    expect(verifyAndParse("")).toBeNull();
+  });
+
+  it("rejects signature with wrong length", () => {
+    const signed = signPayload(JSON.stringify({ test: true }));
+    const lastDot = signed.lastIndexOf(".");
+    const shortSig = signed.substring(0, lastDot) + ".abcd";
+    expect(verifyAndParse(shortSig)).toBeNull();
+  });
+});

--- a/src/server/lib/signed-cookie.ts
+++ b/src/server/lib/signed-cookie.ts
@@ -1,0 +1,28 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+const getSecret = () => process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? "";
+
+export function signPayload(payload: string): string {
+  const signature = createHmac("sha256", getSecret()).update(payload).digest("hex");
+  return `${payload}.${signature}`;
+}
+
+export function verifyAndParse<T = Record<string, unknown>>(signed: string): T | null {
+  const lastDot = signed.lastIndexOf(".");
+  if (lastDot === -1) return null;
+
+  const payload = signed.substring(0, lastDot);
+  const signature = signed.substring(lastDot + 1);
+
+  const expected = createHmac("sha256", getSecret()).update(payload).digest("hex");
+
+  const sigBuf = Buffer.from(signature, "hex");
+  const expBuf = Buffer.from(expected, "hex");
+  if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) return null;
+
+  try {
+    return JSON.parse(payload) as T;
+  } catch {
+    return null;
+  }
+}

--- a/src/server/lib/signed-cookie.ts
+++ b/src/server/lib/signed-cookie.ts
@@ -1,6 +1,10 @@
 import { createHmac, timingSafeEqual } from "crypto";
 
-const getSecret = () => process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? "";
+function getSecret(): string {
+  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
+  if (!secret) throw new Error("AUTH_SECRET or NEXTAUTH_SECRET must be set");
+  return secret;
+}
 
 export function signPayload(payload: string): string {
   const signature = createHmac("sha256", getSecret()).update(payload).digest("hex");

--- a/src/server/trpc/init.ts
+++ b/src/server/trpc/init.ts
@@ -14,19 +14,20 @@ export const createTRPCContext = async (opts?: { req?: Request }) => {
   const headers = opts?.req?.headers ?? new Headers();
 
   // Check for impersonation cookie
-  let impersonating: {
+  interface ImpersonationData {
     adminId: string;
     adminEmail: string;
     targetId: string;
     targetName: string | null;
     targetEmail: string;
-  } | null = null;
+  }
+  let impersonating: ImpersonationData | null = null;
 
   try {
     const cookieStore = await cookies();
     const impCookie = cookieStore.get(IMPERSONATE_COOKIE);
     if (impCookie?.value && session?.user) {
-      const data = verifyAndParse(impCookie.value);
+      const data = verifyAndParse<ImpersonationData>(impCookie.value);
       if (data && data.adminId === session.user.id) {
         impersonating = data;
         // Swap session user to the impersonated user

--- a/src/server/trpc/init.ts
+++ b/src/server/trpc/init.ts
@@ -5,6 +5,7 @@ import { cookies } from "next/headers";
 import { auth } from "../auth";
 import { db } from "../db";
 import { logger } from "../lib/logger";
+import { verifyAndParse } from "../lib/signed-cookie";
 
 const IMPERSONATE_COOKIE = "sharetab-impersonate";
 
@@ -25,9 +26,8 @@ export const createTRPCContext = async (opts?: { req?: Request }) => {
     const cookieStore = await cookies();
     const impCookie = cookieStore.get(IMPERSONATE_COOKIE);
     if (impCookie?.value && session?.user) {
-      const data = JSON.parse(impCookie.value);
-      // Only apply if the real session belongs to the admin who started it
-      if (data.adminId === session.user.id) {
+      const data = verifyAndParse(impCookie.value);
+      if (data && data.adminId === session.user.id) {
         impersonating = data;
         // Swap session user to the impersonated user
         if (session.user) {


### PR DESCRIPTION
## Summary
- Sign the admin impersonation cookie with HMAC-SHA256 using `AUTH_SECRET`
- Verify signature with timing-safe comparison on every request
- Tampered or pre-upgrade unsigned cookies are silently rejected

## Context
Part of the [best-practices improvement initiative](docs/best-practices-proposal.md) — Chunk 6 (Phase 1: Security).

The impersonation cookie previously stored unsigned plain JSON. An admin could manually edit `targetId` in DevTools to impersonate any user without triggering the audit log.

## Changes
- **New:** `src/server/lib/signed-cookie.ts` — shared `signPayload`/`verifyAndParse` utilities with `crypto.timingSafeEqual`
- `src/app/api/admin/impersonate/route.ts` — sign cookie payload before setting
- `src/server/trpc/init.ts` — verify signature when reading cookie, reject if tampered

## Test plan
- [x] `npm test` passes (245 unit tests)
- [x] Timing-safe HMAC comparison prevents timing attacks
- [x] `verifyAndParse` returns null for unsigned cookies (graceful degradation)
- [x] `verifyAndParse` returns null for malformed JSON (try/catch)
- [ ] Manual: impersonate user via admin panel, verify it works
- [ ] Manual: edit cookie value in DevTools, verify it's rejected

> **Note:** In-flight unsigned cookies from before the upgrade will be silently rejected — admin just needs to re-impersonate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)