### PR TITLE
perf: add missing indexes on FK and query-critical columns

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model Account {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
+  @@index([userId])
 }
 
 model Session {
@@ -34,6 +35,8 @@ model Session {
   userId       String
   expires      DateTime
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 model VerificationToken {
@@ -111,6 +114,7 @@ model GroupMember {
   joinedAt DateTime @default(now())
 
   @@unique([userId, groupId])
+  @@index([groupId])
 }
 
 model GroupInvite {
@@ -127,6 +131,8 @@ model GroupInvite {
   group Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now())
+
+  @@index([groupId])
 }
 
 enum GroupRole {
@@ -162,6 +168,7 @@ model Expense {
 
   @@index([groupId])
   @@index([paidById])
+  @@index([addedById])
 }
 
 model ExpenseShare {
@@ -176,6 +183,7 @@ model ExpenseShare {
   user    User    @relation(fields: [userId], references: [id])
 
   @@unique([expenseId, userId])
+  @@index([userId])
 }
 
 enum SplitMode {
@@ -211,6 +219,9 @@ model Receipt {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([groupId])
+  @@index([uploadedById])
 }
 
 model ReceiptItem {
@@ -264,6 +275,8 @@ model Settlement {
   settledAt DateTime @default(now())
 
   @@index([groupId])
+  @@index([fromId])
+  @@index([toId])
 }
 
 // ─── ACTIVITY LOG ──────────────────────────────────────────
@@ -285,6 +298,7 @@ model ActivityLog {
   createdAt DateTime @default(now())
 
   @@index([groupId, createdAt])
+  @@index([userId])
 }
 
 enum ActivityType {
@@ -381,4 +395,7 @@ model GuestSplit {
   createdBy   User?    @relation("GuestSplits", fields: [userId], references: [id])
   expiresAt   DateTime
   createdAt   DateTime @default(now())
+
+  @@index([userId])
+  @@index([expiresAt])
 }


### PR DESCRIPTION
## Summary
- Add `@@index` directives to 13 foreign key columns that were missing database indexes
- Schema-only change — no application code modifications

## Context
Part of the [best-practices improvement initiative](docs/best-practices-proposal.md) — Chunk 1 (Phase 2: Database).

PostgreSQL does not auto-create indexes on FK columns. These 13 columns were causing full table scans on common queries (session lookups, balance calculations, member removal, "My Splits" page, expired split cleanup).

## Changes
**File:** `prisma/schema.prisma` — 13 new `@@index` directives:

| Model | Column | Query Impact |
|---|---|---|
| Account | userId | Session lookup by user |
| Session | userId | Session lookup by user |
| GroupMember | groupId | List members of a group |
| GroupInvite | groupId | List invites for a group |
| Expense | addedById | Expenses added by a user |
| ExpenseShare | userId | Balance calc, placeholder merge |
| Receipt | groupId | Pending receipts list |
| Receipt | uploadedById | Receipts by uploader |
| Settlement | fromId | Member removal, balance calc |
| Settlement | toId | Member removal, balance calc |
| ActivityLog | userId | Member removal cleanup |
| GuestSplit | userId | "My Splits" page |
| GuestSplit | expiresAt | Expired split cleanup |

## Test plan
- [x] `npx prisma validate` passes
- [x] `npm test` passes (252 unit tests)
- [x] Schema-only change — no application logic affected

## Migration
```bash
npx prisma migrate dev --name add-missing-fk-indexes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)