### PR TITLE
refactor: convert GuestSplit.status to Prisma enum + add updatedAt

### DIFF
--- a/e2e/claim-features.spec.ts
+++ b/e2e/claim-features.spec.ts
@@ -182,7 +182,7 @@ test.describe("Claim session — API: mySplits tracks claim sessions", () => {
     expect(data.splits.length).toBeGreaterThanOrEqual(1);
     const bobsPizza = data.splits.find((s: { merchantName: string }) => s.merchantName === "Bob's Pizza");
     expect(bobsPizza).toBeDefined();
-    expect(bobsPizza.status).toBe("claiming");
+    expect(bobsPizza.status).toBe("CLAIMING");
     expect(bobsPizza.total).toBe(3050);
     expect(bobsPizza.peopleCount).toBe(1);
 

--- a/e2e/finalize-session.spec.ts
+++ b/e2e/finalize-session.spec.ts
@@ -236,7 +236,7 @@ test.describe("Finalize claim session", () => {
     const body = await getRes.json();
     const session = body[0]?.result?.data?.json;
 
-    expect(session.status).toBe("finalized");
+    expect(session.status).toBe("FINALIZED");
     expect(session.summary).toHaveLength(2);
 
     // Totals should sum to 2500

--- a/e2e/group-claiming-units.spec.ts
+++ b/e2e/group-claiming-units.spec.ts
@@ -191,7 +191,7 @@ test.describe("Group claiming units", () => {
     );
     const session = (await getRes.json())[0]?.result?.data?.json;
 
-    expect(session.status).toBe("finalized");
+    expect(session.status).toBe("FINALIZED");
     expect(session.summary).toHaveLength(2);
 
     const coupleSummary = session.summary.find(

--- a/e2e/guest-claim-session.spec.ts
+++ b/e2e/guest-claim-session.spec.ts
@@ -36,7 +36,7 @@ test.describe("Guest claiming sessions", () => {
     // Get session -- verify status and initial state
     const getRes = await trpcQuery(ctx, "guest.getSession", { token: shareToken });
     const session = await trpcResult(getRes);
-    expect(session.status).toBe("claiming");
+    expect(session.status).toBe("CLAIMING");
     expect(session.items).toHaveLength(2);
     expect(session.people).toHaveLength(1);
     expect(session.people[0].name).toBe("Alice");
@@ -163,7 +163,7 @@ test.describe("Guest claiming sessions", () => {
     // Get session -- verify finalized status and summary
     const getRes = await trpcQuery(ctx, "guest.getSession", { token: shareToken });
     const session = await trpcResult(getRes);
-    expect(session.status).toBe("finalized");
+    expect(session.status).toBe("FINALIZED");
     expect(session.summary).toBeTruthy();
     expect(session.summary.length).toBeGreaterThanOrEqual(1);
 
@@ -263,7 +263,7 @@ test.describe("Guest claiming sessions", () => {
     const body = await getRes.json();
     const error = body[0]?.error;
     expect(error).toBeTruthy();
-    // getSplit checks status !== "finalized" and returns CONFLICT
+    // getSplit checks status !== "FINALIZED" and returns CONFLICT
     expect(error?.json?.data?.code).toBe("CONFLICT");
 
     await ctx.dispose();
@@ -394,7 +394,7 @@ test.describe("Guest claiming sessions", () => {
     const finalSession = await trpcResult(
       await trpcQuery(ctx, "guest.getSession", { token: shareToken })
     );
-    expect(finalSession.status).toBe("finalized");
+    expect(finalSession.status).toBe("FINALIZED");
     expect(finalSession.summary).toHaveLength(3);
 
     // Alice: $10 (2 beers) + $2.67 (1/3 nachos) + proportional tax/tip

--- a/prisma/migrations/guest_split_status_enum.sql
+++ b/prisma/migrations/guest_split_status_enum.sql
@@ -1,0 +1,25 @@
+-- Migration: Convert GuestSplit.status from String to GuestSplitStatus enum
+-- Run this BEFORE applying the schema change via prisma db push
+-- Only needed for databases with existing GuestSplit rows
+
+-- Step 1: Create the enum type
+DO $$ BEGIN
+  CREATE TYPE "GuestSplitStatus" AS ENUM ('CLAIMING', 'FINALIZED');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- Step 2: Add new enum column
+ALTER TABLE "GuestSplit" ADD COLUMN IF NOT EXISTS "status_new" "GuestSplitStatus" DEFAULT 'FINALIZED';
+
+-- Step 3: Migrate existing data
+UPDATE "GuestSplit" SET "status_new" = CASE
+  WHEN status = 'claiming' THEN 'CLAIMING'::"GuestSplitStatus"
+  ELSE 'FINALIZED'::"GuestSplitStatus"
+END;
+
+-- Step 4: Swap columns
+ALTER TABLE "GuestSplit" DROP COLUMN "status";
+ALTER TABLE "GuestSplit" RENAME COLUMN "status_new" TO "status";
+ALTER TABLE "GuestSplit" ALTER COLUMN "status" SET NOT NULL;
+ALTER TABLE "GuestSplit" ALTER COLUMN "status" SET DEFAULT 'FINALIZED';

--- a/prisma/migrations/guest_split_status_enum.sql
+++ b/prisma/migrations/guest_split_status_enum.sql
@@ -47,6 +47,7 @@ DO $$ BEGIN
     WHERE table_name = 'GuestSplit' AND column_name = 'updatedAt'
   ) THEN
     ALTER TABLE "GuestSplit" ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT NOW();
+    UPDATE "GuestSplit" SET "updatedAt" = "createdAt";
   ELSE
     UPDATE "GuestSplit" SET "updatedAt" = "createdAt" WHERE "updatedAt" IS NULL;
   END IF;

--- a/prisma/migrations/guest_split_status_enum.sql
+++ b/prisma/migrations/guest_split_status_enum.sql
@@ -1,25 +1,41 @@
 -- Migration: Convert GuestSplit.status from String to GuestSplitStatus enum
 -- Run this BEFORE applying the schema change via prisma db push
 -- Only needed for databases with existing GuestSplit rows
+-- Idempotent: safe to re-run
 
--- Step 1: Create the enum type
+-- Step 1: Create the enum type (skip if already exists)
 DO $$ BEGIN
   CREATE TYPE "GuestSplitStatus" AS ENUM ('CLAIMING', 'FINALIZED');
 EXCEPTION
   WHEN duplicate_object THEN null;
 END $$;
 
--- Step 2: Add new enum column
-ALTER TABLE "GuestSplit" ADD COLUMN IF NOT EXISTS "status_new" "GuestSplitStatus" DEFAULT 'FINALIZED';
+-- Step 2: Only migrate if the old text column still exists
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'GuestSplit' AND column_name = 'status'
+    AND data_type = 'text'
+  ) THEN
+    -- Add new enum column
+    ALTER TABLE "GuestSplit" ADD COLUMN "status_new" "GuestSplitStatus" DEFAULT 'FINALIZED';
 
--- Step 3: Migrate existing data
-UPDATE "GuestSplit" SET "status_new" = CASE
-  WHEN status = 'claiming' THEN 'CLAIMING'::"GuestSplitStatus"
-  ELSE 'FINALIZED'::"GuestSplitStatus"
-END;
+    -- Migrate existing data (handle both lowercase and uppercase values)
+    UPDATE "GuestSplit" SET "status_new" = CASE
+      WHEN UPPER(status) = 'CLAIMING' THEN 'CLAIMING'::"GuestSplitStatus"
+      WHEN UPPER(status) = 'FINALIZED' THEN 'FINALIZED'::"GuestSplitStatus"
+      ELSE 'FINALIZED'::"GuestSplitStatus"
+    END;
 
--- Step 4: Swap columns
-ALTER TABLE "GuestSplit" DROP COLUMN "status";
-ALTER TABLE "GuestSplit" RENAME COLUMN "status_new" TO "status";
-ALTER TABLE "GuestSplit" ALTER COLUMN "status" SET NOT NULL;
-ALTER TABLE "GuestSplit" ALTER COLUMN "status" SET DEFAULT 'FINALIZED';
+    -- Log any unexpected values before converting them
+    RAISE NOTICE 'Unexpected status values (converted to FINALIZED): %',
+      (SELECT string_agg(DISTINCT status, ', ') FROM "GuestSplit"
+       WHERE UPPER(status) NOT IN ('CLAIMING', 'FINALIZED'));
+
+    -- Swap columns
+    ALTER TABLE "GuestSplit" DROP COLUMN "status";
+    ALTER TABLE "GuestSplit" RENAME COLUMN "status_new" TO "status";
+    ALTER TABLE "GuestSplit" ALTER COLUMN "status" SET NOT NULL;
+    ALTER TABLE "GuestSplit" ALTER COLUMN "status" SET DEFAULT 'FINALIZED';
+  END IF;
+END $$;

--- a/prisma/migrations/guest_split_status_enum.sql
+++ b/prisma/migrations/guest_split_status_enum.sql
@@ -39,3 +39,15 @@ DO $$ BEGIN
     ALTER TABLE "GuestSplit" ALTER COLUMN "status" SET DEFAULT 'FINALIZED';
   END IF;
 END $$;
+
+-- Step 3: Backfill updatedAt for existing rows (required by @updatedAt)
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'GuestSplit' AND column_name = 'updatedAt'
+  ) THEN
+    ALTER TABLE "GuestSplit" ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT NOW();
+  ELSE
+    UPDATE "GuestSplit" SET "updatedAt" = "createdAt" WHERE "updatedAt" IS NULL;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -377,6 +377,11 @@ model SystemInvite {
   createdAt DateTime @default(now())
 }
 
+enum GuestSplitStatus {
+  CLAIMING
+  FINALIZED
+}
+
 // ─── GUEST SPLITS (no auth required) ──────────────────────
 
 model GuestSplit {
@@ -388,13 +393,14 @@ model GuestSplit {
   people      Json     // [{name}]
   assignments Json     // [{itemIndex, personIndices}]
   summary     Json?    // [{name, itemTotal, tax, tip, total}]
-  paidByIndex      Int      @default(0)
+  paidByIndex      Int              @default(0)
   payerVenmoHandle String?
-  status           String   @default("finalized") // "claiming" | "finalized"
+  status           GuestSplitStatus @default(FINALIZED)
   userId           String?
   createdBy   User?    @relation("GuestSplits", fields: [userId], references: [id])
   expiresAt   DateTime
   createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
   @@index([userId])
   @@index([expiresAt])

--- a/src/app/[locale]/(app)/splits/page.tsx
+++ b/src/app/[locale]/(app)/splits/page.tsx
@@ -76,7 +76,7 @@ export default function SplitsPage() {
           <Card key={split.id} className="relative border-l-[3px] border-l-primary/60 transition-all duration-200 hover:-translate-y-px hover:border-l-primary hover:shadow-md" data-testid={`split-card-${split.id}`}>
             <Link
               href={
-                split.status === "finalized"
+                split.status === "FINALIZED"
                   ? `/split/${split.shareToken}`
                   : `/split/${split.shareToken}/claim`
               }
@@ -90,11 +90,11 @@ export default function SplitsPage() {
                   </span>
                   <Badge
                     variant={
-                      split.status === "finalized" ? "default" : "outline"
+                      split.status === "FINALIZED" ? "default" : "outline"
                     }
                     className="shrink-0 text-[10px]"
                   >
-                    {split.status === "finalized"
+                    {split.status === "FINALIZED"
                       ? t("finalized")
                       : t("claiming")}
                   </Badge>

--- a/src/app/[locale]/split/[token]/claim/page.tsx
+++ b/src/app/[locale]/split/[token]/claim/page.tsx
@@ -102,7 +102,7 @@ export default function ClaimPage({
   });
   const session = trpc.guest.getSession.useQuery(
     { token },
-    { refetchInterval: (query) => (query.state.data?.status === "finalized" || query.state.error) ? false : 3000 }
+    { refetchInterval: (query) => (query.state.data?.status === "FINALIZED" || query.state.error) ? false : 3000 }
   );
 
   const editPersonName = trpc.guest.editPersonName.useMutation({
@@ -236,7 +236,7 @@ export default function ClaimPage({
   // Auto-rejoin from localStorage when session data loads
   useEffect(() => {
     if (autoRejoinAttempted.current || personIndex !== null || !session.data) return;
-    if (session.data.status !== "claiming") return;
+    if (session.data.status !== "CLAIMING") return;
 
     const stored = getStoredClaimIdentity(token);
     if (!stored) return;
@@ -476,7 +476,7 @@ export default function ClaimPage({
   const currency = data.receiptData.currency;
 
   // --- Finalized state ---
-  if (data.status === "finalized") {
+  if (data.status === "FINALIZED") {
     return (
       <div className="space-y-6 pb-8">
         <div className="text-center space-y-2 pt-4">

--- a/src/server/trpc/routers/guest.ts
+++ b/src/server/trpc/routers/guest.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "crypto";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import { Prisma } from "@/generated/prisma/client";
+import { Prisma, GuestSplitStatus } from "@/generated/prisma/client";
 import { createTRPCRouter, publicProcedure, protectedProcedure } from "../init";
 import { processReceiptImage } from "../../lib/receipt-processor";
 import { logger } from "../../lib/logger";
@@ -449,7 +449,7 @@ export const guestRouter = createTRPCRouter({
       if (split.expiresAt < new Date()) {
         throw new TRPCError({ code: "NOT_FOUND", message: "This split has expired" });
       }
-      if (split.status !== "finalized") {
+      if (split.status !== GuestSplitStatus.FINALIZED) {
         throw new TRPCError({
           code: "CONFLICT",
           message: "This split is not yet finalized. Please wait for the split creator to finalize it.",
@@ -557,7 +557,7 @@ export const guestRouter = createTRPCRouter({
           assignments: [] as unknown as Prisma.InputJsonValue,
           paidByIndex,
           payerVenmoHandle: claimPayerVenmoHandle,
-          status: "claiming",
+          status: GuestSplitStatus.CLAIMING,
           userId: ctx.session?.user?.id ?? null,
           expiresAt: createExpiryDate(),
         },
@@ -588,7 +588,7 @@ export const guestRouter = createTRPCRouter({
           });
           if (!session) throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
           if (session.expiresAt < new Date()) throw new TRPCError({ code: "NOT_FOUND", message: "Session expired" });
-          if (session.status !== "claiming") throw new TRPCError({ code: "BAD_REQUEST", message: "Session is no longer accepting claims" });
+          if (session.status !== GuestSplitStatus.CLAIMING) throw new TRPCError({ code: "BAD_REQUEST", message: "Session is no longer accepting claims" });
 
           const people = [...(session.people as GuestSessionPerson[])];
           const normalizedName = normalizeGuestName(input.name);
@@ -657,7 +657,7 @@ export const guestRouter = createTRPCRouter({
           });
           if (!session) throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
           if (session.expiresAt < new Date()) throw new TRPCError({ code: "NOT_FOUND", message: "Session expired" });
-          if (session.status !== "claiming") throw new TRPCError({ code: "BAD_REQUEST", message: "Session is finalized" });
+          if (session.status !== GuestSplitStatus.CLAIMING) throw new TRPCError({ code: "BAD_REQUEST", message: "Session is finalized" });
 
           const people = [...(session.people as GuestSessionPerson[])];
           const isParticipant = people.some(p => p.personToken === input.personToken);
@@ -700,7 +700,7 @@ export const guestRouter = createTRPCRouter({
           });
           if (!session) throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
           if (session.expiresAt < new Date()) throw new TRPCError({ code: "NOT_FOUND", message: "Session expired" });
-          if (session.status !== "claiming") throw new TRPCError({ code: "BAD_REQUEST", message: "Session is finalized" });
+          if (session.status !== GuestSplitStatus.CLAIMING) throw new TRPCError({ code: "BAD_REQUEST", message: "Session is finalized" });
 
           const people = [...(session.people as GuestSessionPerson[])];
           const isParticipant = people.some(p => p.personToken === input.personToken);
@@ -764,7 +764,7 @@ export const guestRouter = createTRPCRouter({
           });
           if (!session) throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
           if (session.expiresAt < new Date()) throw new TRPCError({ code: "NOT_FOUND", message: "Session expired" });
-          if (session.status !== "claiming") throw new TRPCError({ code: "BAD_REQUEST", message: "Session is finalized" });
+          if (session.status !== GuestSplitStatus.CLAIMING) throw new TRPCError({ code: "BAD_REQUEST", message: "Session is finalized" });
 
           const people = session.people as GuestSessionPerson[];
           const isParticipant = people.some(p => p.personToken === input.personToken);
@@ -840,7 +840,7 @@ export const guestRouter = createTRPCRouter({
           });
           if (!session) throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
           if (session.expiresAt < new Date()) throw new TRPCError({ code: "NOT_FOUND", message: "Session expired" });
-          if (session.status !== "claiming") throw new TRPCError({ code: "BAD_REQUEST", message: "Session is no longer accepting claims" });
+          if (session.status !== GuestSplitStatus.CLAIMING) throw new TRPCError({ code: "BAD_REQUEST", message: "Session is no longer accepting claims" });
 
           const people = session.people as GuestSessionPerson[];
           const items = session.items as { name: string; quantity: number; unitPrice: number; totalPrice: number }[];
@@ -986,7 +986,7 @@ export const guestRouter = createTRPCRouter({
           });
           if (!session) throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
           if (session.expiresAt < new Date()) throw new TRPCError({ code: "NOT_FOUND", message: "Session expired" });
-          if (session.status !== "claiming") throw new TRPCError({ code: "BAD_REQUEST", message: "Session already finalized" });
+          if (session.status !== GuestSplitStatus.CLAIMING) throw new TRPCError({ code: "BAD_REQUEST", message: "Session already finalized" });
 
           const items = session.items as { name: string; quantity: number; unitPrice: number; totalPrice: number }[];
           const people = session.people as GuestSessionPerson[];
@@ -1033,7 +1033,7 @@ export const guestRouter = createTRPCRouter({
           await tx.guestSplit.update({
             where: { id: session.id },
             data: {
-              status: "finalized",
+              status: GuestSplitStatus.FINALIZED,
               summary: summaryWithNames as unknown as Prisma.InputJsonValue,
               assignments: assignments as unknown as Prisma.InputJsonValue,
               ...(input.tipOverride !== undefined && {


### PR DESCRIPTION
## Summary
- Convert `GuestSplit.status` from `String` to `GuestSplitStatus` enum (CLAIMING, FINALIZED)
- Add `updatedAt` field to `GuestSplit` (10 update sites, was missing audit timestamp)
- Include SQL migration script for existing databases

## Context
Part of the [best-practices improvement initiative](docs/best-practices-proposal.md) — Chunk 3 (Phase 2: Database).

`GuestSplit.status` used plain strings with 11+ raw string comparisons. A typo would silently pass. The model was also the most heavily mutated (10 update sites) with no `updatedAt` field.

## Changes
- `prisma/schema.prisma`: New `GuestSplitStatus` enum, `updatedAt` on GuestSplit
- `src/server/trpc/routers/guest.ts`: Import `GuestSplitStatus`, replace all string literals with enum
- `src/app/[locale]/split/[token]/claim/page.tsx`: Update comparisons to uppercase enum values
- `src/app/[locale]/(app)/splits/page.tsx`: Same
- `e2e/*.spec.ts` (4 files): Update status assertions to uppercase
- `prisma/migrations/guest_split_status_enum.sql`: Manual migration for existing databases

## Data Migration
For existing databases with GuestSplit rows, run the SQL migration **before** `prisma db push`:
```bash
psql -f prisma/migrations/guest_split_status_enum.sql
```
New installs don't need this — `prisma db push` handles it automatically.

## Test plan
- [x] `npx prisma validate` passes
- [x] `npm test` passes (252 unit tests)
- [x] All 11 status comparisons use `GuestSplitStatus` enum
- [x] Frontend uses uppercase serialized values
- [x] E2e tests updated for uppercase values

🤖 Generated with [Claude Code](https://claude.com/claude-code)