### PR TITLE
perf: optimize balance queries with targeted select

### DIFF
--- a/src/server/trpc/routers/balances.ts
+++ b/src/server/trpc/routers/balances.ts
@@ -9,10 +9,15 @@ export const balancesRouter = createTRPCRouter({
       const [expenses, settlements] = await Promise.all([
         ctx.db.expense.findMany({
           where: { groupId: input.groupId },
-          include: { shares: true },
+          select: {
+            paidById: true,
+            amount: true,
+            shares: { select: { userId: true, amount: true } },
+          },
         }),
         ctx.db.settlement.findMany({
           where: { groupId: input.groupId },
+          select: { fromId: true, toId: true, amount: true },
         }),
       ]);
 
@@ -26,10 +31,15 @@ export const balancesRouter = createTRPCRouter({
       const [expenses, settlements] = await Promise.all([
         ctx.db.expense.findMany({
           where: { groupId: input.groupId },
-          include: { shares: true },
+          select: {
+            paidById: true,
+            amount: true,
+            shares: { select: { userId: true, amount: true } },
+          },
         }),
         ctx.db.settlement.findMany({
           where: { groupId: input.groupId },
+          select: { fromId: true, toId: true, amount: true },
         }),
       ]);
 
@@ -41,11 +51,19 @@ export const balancesRouter = createTRPCRouter({
   getOverallDebts: protectedProcedure.query(async ({ ctx }) => {
     const groups = await ctx.db.group.findMany({
       where: { members: { some: { userId: ctx.user.id } }, archivedAt: null },
-      include: {
-        expenses: { include: { shares: true } },
-        settlements: true,
+      select: {
+        expenses: {
+          select: {
+            paidById: true,
+            amount: true,
+            shares: { select: { userId: true, amount: true } },
+          },
+        },
+        settlements: {
+          select: { fromId: true, toId: true, amount: true },
+        },
         members: {
-          include: { user: { select: { id: true, name: true, venmoUsername: true } } },
+          select: { user: { select: { id: true, name: true, venmoUsername: true } } },
         },
       },
     });
@@ -122,11 +140,18 @@ export const balancesRouter = createTRPCRouter({
   getDashboard: protectedProcedure.query(async ({ ctx }) => {
     const groups = await ctx.db.group.findMany({
       where: { members: { some: { userId: ctx.user.id } }, archivedAt: null },
-      include: {
-        expenses: { include: { shares: true } },
-        settlements: true,
-        members: {
-          include: { user: { select: { id: true, name: true, image: true } } },
+      select: {
+        id: true,
+        name: true,
+        expenses: {
+          select: {
+            paidById: true,
+            amount: true,
+            shares: { select: { userId: true, amount: true } },
+          },
+        },
+        settlements: {
+          select: { fromId: true, toId: true, amount: true },
         },
       },
     });


### PR DESCRIPTION
## Summary
- Replace `include` (loads full models) with targeted `select` in all 4 balance endpoints
- Remove unused `members` include from `getDashboard`
- Only fetch fields that `computeBalances`/`simplifyDebts` actually use

## Context
Part of the [best-practices improvement initiative](docs/best-practices-proposal.md) — Chunk 7 (Phase 3: Performance).

Balance endpoints were loading full Expense models (title, description, category, dates, createdAt, updatedAt, etc.) when `computeBalances()` only reads `paidById`, `amount`, and `shares.{userId, amount}`. `getDashboard` also included `members` data that was never accessed in the handler.

## Changes
**File:** `src/server/trpc/routers/balances.ts`

| Endpoint | Before | After |
|---|---|---|
| `getGroupBalances` | `include: { shares: true }` + full Settlement | `select: { paidById, amount, shares: { userId, amount } }` + `select: { fromId, toId, amount }` |
| `getSimplifiedDebts` | Same as above | Same optimization |
| `getOverallDebts` | `include` all + `members` | `select` on expenses/settlements, keep `members` (needed for user info) |
| `getDashboard` | `include` all + `members` | `select` on expenses/settlements + `id`/`name`, remove unused `members` |

## Test plan
- [x] `npm test` passes (252 unit tests)
- [x] Types match `computeBalances` input signature exactly
- [x] `getDashboard` handler only accesses `group.id`, `group.name`, `group.expenses`, `group.settlements` — confirmed `members` is unused

🤖 Generated with [Claude Code](https://claude.com/claude-code)