### PR TITLE
refactor: extract avatar color and initials into shared utilities

### DIFF
--- a/src/app/[locale]/(app)/dashboard/page.tsx
+++ b/src/app/[locale]/(app)/dashboard/page.tsx
@@ -17,37 +17,9 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import { Link } from "@/i18n/navigation";
+import { getInitials, avatarColor } from "@/lib/avatar";
 
 const GROUPS_PER_PAGE = 6;
-
-function getInitials(name: string): string {
-  return name
-    .split(" ")
-    .map((part) => part[0])
-    .filter(Boolean)
-    .slice(0, 2)
-    .join("")
-    .toUpperCase();
-}
-
-const avatarColors = [
-  "bg-blue-500",
-  "bg-emerald-500",
-  "bg-violet-500",
-  "bg-amber-500",
-  "bg-rose-500",
-  "bg-cyan-500",
-  "bg-fuchsia-500",
-  "bg-lime-500",
-];
-
-function avatarColor(userId: string): string {
-  let hash = 0;
-  for (let i = 0; i < userId.length; i++) {
-    hash = (hash * 31 + userId.charCodeAt(i)) | 0;
-  }
-  return avatarColors[Math.abs(hash) % avatarColors.length];
-}
 
 /* ------------------------------------------------------------------ */
 /*  Skeleton / loading helpers                                        */

--- a/src/app/[locale]/(app)/groups/[groupId]/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/page.tsx
@@ -27,37 +27,7 @@ import { Link } from "@/i18n/navigation";
 import { toast } from "sonner";
 import { InviteDialog } from "@/components/groups/invite-dialog";
 import { SettleDialog } from "@/components/groups/settle-dialog";
-
-function getInitials(name?: string | null, email?: string | null): string {
-  if (name) {
-    return name
-      .split(" ")
-      .map((n) => n[0])
-      .join("")
-      .toUpperCase()
-      .slice(0, 2);
-  }
-  return email?.[0]?.toUpperCase() ?? "?";
-}
-
-const avatarColors = [
-  "bg-blue-500",
-  "bg-emerald-500",
-  "bg-violet-500",
-  "bg-amber-500",
-  "bg-rose-500",
-  "bg-cyan-500",
-  "bg-fuchsia-500",
-  "bg-lime-500",
-];
-
-function avatarColor(userId: string): string {
-  let hash = 0;
-  for (let i = 0; i < userId.length; i++) {
-    hash = (hash * 31 + userId.charCodeAt(i)) | 0;
-  }
-  return avatarColors[Math.abs(hash) % avatarColors.length];
-}
+import { getInitials, avatarColor } from "@/lib/avatar";
 
 export default function GroupDetailPage({
   params,

--- a/src/app/[locale]/split/[token]/claim/page.tsx
+++ b/src/app/[locale]/split/[token]/claim/page.tsx
@@ -16,29 +16,7 @@ import { Check, Loader2, Users, Receipt, ArrowRight, Image as ImageIcon, Pencil,
 import { toast } from "sonner";
 import { Link } from "@/i18n/navigation";
 import { buildVenmoPayUrl, isValidVenmoHandle } from "@/lib/venmo";
-
-// Shared avatar color palette (matches the existing split page)
-const colors = [
-  "bg-red-100 text-red-700",
-  "bg-blue-100 text-blue-700",
-  "bg-green-100 text-green-700",
-  "bg-purple-100 text-purple-700",
-  "bg-amber-100 text-amber-700",
-  "bg-pink-100 text-pink-700",
-  "bg-teal-100 text-teal-700",
-  "bg-indigo-100 text-indigo-700",
-];
-
-function initials(name: string): string {
-  return (
-    name
-      .split(" ")
-      .map((n) => n[0])
-      .join("")
-      .toUpperCase()
-      .slice(0, 2) || "?"
-  );
-}
+import { getInitials, guestAvatarColor } from "@/lib/avatar";
 
 function getStoredClaimIdentity(token: string): StoredClaimIdentity | null {
   if (typeof window === "undefined") return null;
@@ -533,8 +511,8 @@ export default function ClaimPage({
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
                       <Avatar className="h-8 w-8">
-                        <AvatarFallback className={`text-xs font-semibold ${colors[person.personIndex % colors.length]}`}>
-                          {initials(person.name)}
+                        <AvatarFallback className={`text-xs font-semibold ${guestAvatarColor(person.personIndex)}`}>
+                          {getInitials(person.name)}
                         </AvatarFallback>
                       </Avatar>
                       <span className="font-medium">{person.name}</span>
@@ -670,9 +648,9 @@ export default function ClaimPage({
                   >
                     <Avatar className="h-6 w-6">
                       <AvatarFallback
-                        className={`text-[10px] font-semibold ${colors[idx % colors.length]}`}
+                        className={`text-[10px] font-semibold ${guestAvatarColor(idx)}`}
                       >
-                        {initials(person.name)}
+                        {getInitials(person.name)}
                       </AvatarFallback>
                     </Avatar>
                     <span className="text-sm font-medium">
@@ -744,9 +722,9 @@ export default function ClaimPage({
                     >
                       <Avatar className="h-6 w-6">
                         <AvatarFallback
-                          className={`text-[10px] font-semibold ${colors[idx % colors.length]}`}
+                          className={`text-[10px] font-semibold ${guestAvatarColor(idx)}`}
                         >
-                          {initials(person.name)}
+                          {getInitials(person.name)}
                         </AvatarFallback>
                       </Avatar>
                       <span className="text-sm font-medium">{person.name}</span>
@@ -867,9 +845,9 @@ export default function ClaimPage({
               >
                 <Avatar className="h-6 w-6 shrink-0">
                   <AvatarFallback
-                    className={`text-[10px] font-semibold ${colors[idx % colors.length]}`}
+                    className={`text-[10px] font-semibold ${guestAvatarColor(idx)}`}
                   >
-                    {initials(person.name)}
+                    {getInitials(person.name)}
                   </AvatarFallback>
                 </Avatar>
                 {editingPersonIdx === idx ? (
@@ -988,9 +966,9 @@ export default function ClaimPage({
             >
               <Avatar className="h-6 w-6">
                 <AvatarFallback
-                  className={`text-[10px] font-semibold ${idx === personIndex ? "bg-primary-foreground/20 text-primary-foreground" : colors[idx % colors.length]}`}
+                  className={`text-[10px] font-semibold ${idx === personIndex ? "bg-primary-foreground/20 text-primary-foreground" : guestAvatarColor(idx)}`}
                 >
-                  {initials(person.name)}
+                  {getInitials(person.name)}
                 </AvatarFallback>
               </Avatar>
               <span className="text-sm font-medium">
@@ -1168,9 +1146,9 @@ export default function ClaimPage({
                             {otherClaimants.map((pi) => (
                               <Avatar key={pi} className="h-5 w-5 border-2 border-background">
                                 <AvatarFallback
-                                  className={`text-[8px] font-semibold ${colors[pi % colors.length]}`}
+                                  className={`text-[8px] font-semibold ${guestAvatarColor(pi)}`}
                                 >
-                                  {initials(data.people[pi]?.name ?? "?")}
+                                  {getInitials(data.people[pi]?.name ?? "?")}
                                 </AvatarFallback>
                               </Avatar>
                             ))}
@@ -1212,9 +1190,9 @@ export default function ClaimPage({
                     <div className="flex items-center gap-3">
                       <Avatar className="h-8 w-8">
                         <AvatarFallback
-                          className={`text-xs font-semibold ${colors[person.personIndex % colors.length]}`}
+                          className={`text-xs font-semibold ${guestAvatarColor(person.personIndex)}`}
                         >
-                          {initials(personName)}
+                          {getInitials(personName)}
                         </AvatarFallback>
                       </Avatar>
                       <span className="font-medium">

--- a/src/app/[locale]/split/[token]/page.tsx
+++ b/src/app/[locale]/split/[token]/page.tsx
@@ -13,6 +13,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Copy, Share2, Receipt, ArrowRight, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Link } from "@/i18n/navigation";
+import { getInitials } from "@/lib/avatar";
 import { buildVenmoPayUrl, isValidVenmoHandle } from "@/lib/venmo";
 
 export default function SharedSplitPage({
@@ -106,20 +107,7 @@ export default function SharedSplitPage({
     toast.success("Link copied to clipboard");
   }
 
-  const initials = (name: string) =>
-    name.split(" ").map((n) => n[0]).join("").toUpperCase().slice(0, 2) || "?";
-
-  // Color palette for avatars
-  const colors = [
-    "bg-red-100 text-red-700",
-    "bg-blue-100 text-blue-700",
-    "bg-green-100 text-green-700",
-    "bg-purple-100 text-purple-700",
-    "bg-amber-100 text-amber-700",
-    "bg-pink-100 text-pink-700",
-    "bg-teal-100 text-teal-700",
-    "bg-indigo-100 text-indigo-700",
-  ];
+  const initials = (name: string) => getInitials(name);
 
   return (
     <div className="space-y-6 pb-24" data-testid="split-result">

--- a/src/app/[locale]/split/[token]/page.tsx
+++ b/src/app/[locale]/split/[token]/page.tsx
@@ -13,7 +13,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Copy, Share2, Receipt, ArrowRight, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Link } from "@/i18n/navigation";
-import { getInitials } from "@/lib/avatar";
+import { getInitials, guestAvatarColor } from "@/lib/avatar";
 import { buildVenmoPayUrl, isValidVenmoHandle } from "@/lib/venmo";
 
 export default function SharedSplitPage({
@@ -107,7 +107,7 @@ export default function SharedSplitPage({
     toast.success("Link copied to clipboard");
   }
 
-  const initials = (name: string) => getInitials(name);
+  const initials = getInitials;
 
   return (
     <div className="space-y-6 pb-24" data-testid="split-result">
@@ -176,7 +176,7 @@ export default function SharedSplitPage({
                 <div className="flex items-center justify-between mb-3">
                   <div className="flex items-center gap-3">
                     <Avatar className="h-10 w-10">
-                      <AvatarFallback className={`text-sm font-semibold ${colors[idx % colors.length]}`}>
+                      <AvatarFallback className={`text-sm font-semibold ${guestAvatarColor(idx)}`}>
                         {initials(person.name)}
                       </AvatarFallback>
                     </Avatar>

--- a/src/app/[locale]/split/page.tsx
+++ b/src/app/[locale]/split/page.tsx
@@ -405,7 +405,7 @@ export default function GuestSplitPage() {
     }
   }
 
-  const initials = (name: string) => getInitials(name);
+  const initials = getInitials;
 
   return (
     <div className="space-y-6 pb-24">

--- a/src/app/[locale]/split/page.tsx
+++ b/src/app/[locale]/split/page.tsx
@@ -18,6 +18,7 @@ import {
   Share2, Pencil, Image as ImageIcon, RefreshCw, Scissors,
 } from "lucide-react";
 import { toast } from "sonner";
+import { getInitials } from "@/lib/avatar";
 
 type Step = "upload" | "processing" | "people" | "assign";
 
@@ -404,8 +405,7 @@ export default function GuestSplitPage() {
     }
   }
 
-  const initials = (name: string) =>
-    name.split(" ").map((n) => n[0]).join("").toUpperCase().slice(0, 2) || "?";
+  const initials = (name: string) => getInitials(name);
 
   return (
     <div className="space-y-6 pb-24">

--- a/src/lib/avatar.test.ts
+++ b/src/lib/avatar.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { avatarColor, guestAvatarColor, getInitials } from "./avatar";
+
+describe("avatarColor", () => {
+  it("returns a Tailwind bg class", () => {
+    expect(avatarColor("user-123")).toMatch(/^bg-\w+-500$/);
+  });
+
+  it("returns the same color for the same userId", () => {
+    expect(avatarColor("abc")).toBe(avatarColor("abc"));
+  });
+
+  it("returns different colors for different userIds", () => {
+    const colors = new Set(["a", "b", "c", "d", "e"].map(avatarColor));
+    expect(colors.size).toBeGreaterThan(1);
+  });
+});
+
+describe("guestAvatarColor", () => {
+  it("returns a guest color class", () => {
+    expect(guestAvatarColor(0)).toContain("bg-");
+    expect(guestAvatarColor(0)).toContain("text-");
+  });
+
+  it("wraps around at palette length", () => {
+    expect(guestAvatarColor(0)).toBe(guestAvatarColor(8));
+  });
+
+  it("handles negative index", () => {
+    expect(guestAvatarColor(-1)).toMatch(/^bg-/);
+  });
+
+  it("handles non-integer index", () => {
+    expect(guestAvatarColor(1.7)).toMatch(/^bg-/);
+  });
+});
+
+describe("getInitials", () => {
+  it("returns first letters of name parts", () => {
+    expect(getInitials("Alice Johnson")).toBe("AJ");
+  });
+
+  it("limits to 2 characters", () => {
+    expect(getInitials("Alice Bob Charlie")).toBe("AB");
+  });
+
+  it("falls back to email initial", () => {
+    expect(getInitials(null, "alice@test.com")).toBe("A");
+  });
+
+  it("returns ? when no name or email", () => {
+    expect(getInitials(null, null)).toBe("?");
+  });
+
+  it("handles single name", () => {
+    expect(getInitials("Alice")).toBe("A");
+  });
+
+  it("uppercases", () => {
+    expect(getInitials("alice johnson")).toBe("AJ");
+  });
+});

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -29,7 +29,7 @@ const guestColors = [
 ];
 
 export function guestAvatarColor(index: number): string {
-  return guestColors[index % guestColors.length];
+  return guestColors[Math.abs(Math.floor(index)) % guestColors.length];
 }
 
 export function getInitials(name?: string | null, email?: string | null): string {

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -1,0 +1,45 @@
+const avatarColors = [
+  "bg-blue-500",
+  "bg-emerald-500",
+  "bg-violet-500",
+  "bg-amber-500",
+  "bg-rose-500",
+  "bg-cyan-500",
+  "bg-fuchsia-500",
+  "bg-lime-500",
+];
+
+export function avatarColor(userId: string): string {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) | 0;
+  }
+  return avatarColors[Math.abs(hash) % avatarColors.length];
+}
+
+const guestColors = [
+  "bg-red-100 text-red-700",
+  "bg-blue-100 text-blue-700",
+  "bg-green-100 text-green-700",
+  "bg-purple-100 text-purple-700",
+  "bg-amber-100 text-amber-700",
+  "bg-pink-100 text-pink-700",
+  "bg-teal-100 text-teal-700",
+  "bg-indigo-100 text-indigo-700",
+];
+
+export function guestAvatarColor(index: number): string {
+  return guestColors[index % guestColors.length];
+}
+
+export function getInitials(name?: string | null, email?: string | null): string {
+  if (name) {
+    return name
+      .split(" ")
+      .map((n) => n[0])
+      .join("")
+      .toUpperCase()
+      .slice(0, 2) || "?";
+  }
+  return email?.[0]?.toUpperCase() ?? "?";
+}


### PR DESCRIPTION
## Summary
- Create `src/lib/avatar.ts` with shared `avatarColor`, `guestAvatarColor`, and `getInitials` utilities
- Remove duplicated code from 5 files (net -47 lines)

## Context
Part of the [best-practices improvement initiative](docs/best-practices-proposal.md) — Chunk 9 (Phase 4: Frontend Quality).

Avatar color logic (hash function + 8-color palette) was duplicated identically in dashboard and group detail pages. `getInitials` was duplicated 5 times with slightly different signatures. Guest split pages had a separate index-based color palette duplicated in 2 files.

## Changes
- **New:** `src/lib/avatar.ts` — three utilities matching exact production palettes (8 colors each)
- `dashboard/page.tsx`: Remove local `avatarColors`, `avatarColor`, `getInitials` (-28 lines)
- `groups/[groupId]/page.tsx`: Same (-29 lines)
- `split/page.tsx`: Replace inline `initials` with import
- `split/[token]/page.tsx`: Replace inline `initials` + remove unused `colors` array
- `split/[token]/claim/page.tsx`: Replace `colors[]` + `initials()` with imports

## Test plan
- [x] `npm test` passes (252 unit tests)
- [x] Same 8-color palette preserved exactly — no visual change
- [x] `getInitials` handles both signatures: `(name)` and `(name, email)`
- [x] No remaining local avatar/initials declarations in `src/app/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)