### PR TITLE
refactor: replace bare Loading text with shared LoadingSpinner

### DIFF
--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ArrowLeft } from "lucide-react";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { EqualSplit } from "@/components/expenses/equal-split";
 import { ExactSplit } from "@/components/expenses/exact-split";
 import { PercentageSplit } from "@/components/expenses/percentage-split";
@@ -101,7 +102,7 @@ export default function EditExpensePage({
   }
 
   if (expense.isLoading || group.isLoading) {
-    return <p className="text-muted-foreground">Loading...</p>;
+    return <LoadingSpinner />;
   }
   if (!expense.data) {
     return (

--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/page.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { ArrowLeft, Trash2, Pencil } from "lucide-react";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
 
 export default function ExpenseDetailPage({
   params,
@@ -25,7 +26,7 @@ export default function ExpenseDetailPage({
     onSuccess: () => router.push(`/groups/${groupId}`),
   });
 
-  if (expense.isLoading) return <p className="text-muted-foreground">Loading...</p>;
+  if (expense.isLoading) return <LoadingSpinner />;
   if (!expense.data) {
     return (
       <div className="mx-auto max-w-md py-16 text-center">

--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/new/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/new/page.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ArrowLeft } from "lucide-react";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { EqualSplit } from "@/components/expenses/equal-split";
 import { ExactSplit } from "@/components/expenses/exact-split";
 import { PercentageSplit } from "@/components/expenses/percentage-split";
@@ -85,7 +86,7 @@ export default function NewExpensePage({
     });
   }
 
-  if (group.isLoading) return <p className="text-muted-foreground">Loading...</p>;
+  if (group.isLoading) return <LoadingSpinner />;
 
   return (
     <div className="mx-auto max-w-lg space-y-6">

--- a/src/app/[locale]/(app)/groups/[groupId]/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/page.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import {
   Plus,
   Settings,
@@ -72,7 +73,7 @@ export default function GroupDetailPage({
   useEffect(() => () => { if (settleTimerRef.current) clearTimeout(settleTimerRef.current); }, []);
 
   if (group.isLoading && !group.isError) {
-    return <p className="text-muted-foreground">Loading...</p>;
+    return <LoadingSpinner />;
   }
 
   if (!group.data) {
@@ -343,7 +344,7 @@ export default function GroupDetailPage({
           )}
         </div>
 
-        {expenses.isLoading && <p className="text-muted-foreground">Loading...</p>}
+        {expenses.isLoading && <LoadingSpinner />}
 
         {expenses.data?.expenses.length === 0 && (
           <Card>

--- a/src/app/[locale]/(app)/groups/[groupId]/settings/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/settings/page.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
 import { Archive, ArchiveRestore, ArrowLeft, Pencil, Trash2, UserPlus, Check, X } from "lucide-react";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
 
 export default function GroupSettingsPage({
   params,
@@ -96,7 +97,7 @@ export default function GroupSettingsPage({
     addPlaceholder.mutate({ groupId, name: placeholderName.trim() });
   }
 
-  if (group.isLoading) return <p className="text-muted-foreground">Loading...</p>;
+  if (group.isLoading) return <LoadingSpinner />;
   if (!group.data) return <p className="text-destructive">Group not found.</p>;
 
   const placeholders = group.data.members.filter((m) => m.user.isPlaceholder);

--- a/src/app/[locale]/(app)/groups/page.tsx
+++ b/src/app/[locale]/(app)/groups/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Archive, ArchiveRestore, Plus, Search } from "lucide-react";
 
 const GROUPS_PER_PAGE = 12;
@@ -81,7 +82,7 @@ function GroupsContent() {
         </div>
       )}
 
-      {isLoading && <p className="text-muted-foreground">Loading...</p>}
+      {isLoading && <LoadingSpinner />}
 
       {!isLoading && activeList?.length === 0 && !search && (
         <Card>

--- a/src/components/ui/loading-spinner.tsx
+++ b/src/components/ui/loading-spinner.tsx
@@ -1,10 +1,15 @@
 import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
 
-export function LoadingSpinner({ text }: { text?: string }) {
+export function LoadingSpinner({ text, className }: { text?: string; className?: string }) {
   return (
-    <div className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn("flex items-center justify-center gap-2 py-12 text-muted-foreground", className)}
+    >
       <Loader2 className="h-5 w-5 animate-spin" />
-      {text && <span>{text}</span>}
+      {text ? <span>{text}</span> : <span className="sr-only">Loading</span>}
     </div>
   );
 }

--- a/src/components/ui/loading-spinner.tsx
+++ b/src/components/ui/loading-spinner.tsx
@@ -1,0 +1,10 @@
+import { Loader2 } from "lucide-react";
+
+export function LoadingSpinner({ text }: { text?: string }) {
+  return (
+    <div className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
+      <Loader2 className="h-5 w-5 animate-spin" />
+      {text && <span>{text}</span>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Create shared `LoadingSpinner` component with animated Loader2 icon
- Replace all 7 bare `<p>Loading...</p>` instances across group pages

## Context
Part of the [best-practices improvement initiative](docs/best-practices-proposal.md) — Chunk 12 (Phase 4: Frontend Quality).

Group pages used plain "Loading..." text while split/admin pages used animated spinners. This creates an inconsistent loading experience.

## Changes
- **New:** `src/components/ui/loading-spinner.tsx` — `Loader2` icon with `animate-spin`, optional text prop
- 6 page files updated to import and use `<LoadingSpinner />`

## Test plan
- [x] `npm test` passes (265 unit tests)
- [x] No remaining bare "Loading..." text in `src/app/`
- [x] Visual: centered spinner with animation replaces plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)