### PR TITLE
fix: resolve strict mode violation in group-claiming badge test

### DIFF
--- a/e2e/group-claiming-units.spec.ts
+++ b/e2e/group-claiming-units.spec.ts
@@ -115,8 +115,8 @@ test.describe("Group claiming units", () => {
 
     await expect(page.locator('[data-testid^="claim-item-"]').first()).toBeVisible({ timeout: 15000 });
 
-    // Should NOT show any group badge
-    await expect(page.getByTestId("group-badge-0")).not.toBeVisible();
+    // Should NOT show any group badge for any person
+    await expect(page.locator('[data-testid^="group-badge-"]')).toHaveCount(0);
 
     await page.close();
     await browserCtx.close();
@@ -385,7 +385,7 @@ test.describe("Group claiming units", () => {
     await expect(page.locator('[data-sonner-toast]')).toBeHidden({ timeout: 10000 });
 
     // No group badge initially (solo)
-    await expect(page.getByTestId("group-badge-0")).not.toBeVisible();
+    await expect(page.locator('[data-testid^="group-badge-"]')).toHaveCount(0);
 
     // Click edit pencil on Alice
     await page.getByTestId("edit-person-0").click();

--- a/e2e/group-claiming-units.spec.ts
+++ b/e2e/group-claiming-units.spec.ts
@@ -76,8 +76,8 @@ test.describe("Group claiming units", () => {
 
     await expect(page.locator('[data-testid^="claim-item-"]').first()).toBeVisible({ timeout: 15000 });
 
-    // Should show group badge (×2)
-    await expect(page.getByText("×2").first()).toBeVisible();
+    // Should show group badge (×2) — Alice & Bob is person index 1 (creator Alice is 0)
+    await expect(page.getByTestId("group-badge-1")).toBeVisible();
 
     await page.close();
     await browserCtx.close();
@@ -116,8 +116,7 @@ test.describe("Group claiming units", () => {
     await expect(page.locator('[data-testid^="claim-item-"]').first()).toBeVisible({ timeout: 15000 });
 
     // Should NOT show any group badge
-    await expect(page.getByText("×2")).not.toBeVisible();
-    await expect(page.getByText("×3")).not.toBeVisible();
+    await expect(page.getByTestId("group-badge-0")).not.toBeVisible();
 
     await page.close();
     await browserCtx.close();
@@ -342,7 +341,7 @@ test.describe("Group claiming units", () => {
     await expect(saveBtn).toContainText(/saved/i, { timeout: 10000 });
 
     // Group badge should be visible
-    await expect(page.getByText("×2").first()).toBeVisible();
+    await expect(page.getByTestId("group-badge-0")).toBeVisible();
 
     // Per-person totals should show the couple paying more
     await expect(page.getByText("Alice & Bob").first()).toBeVisible();
@@ -386,7 +385,7 @@ test.describe("Group claiming units", () => {
     await expect(page.locator('[data-sonner-toast]')).toBeHidden({ timeout: 10000 });
 
     // No group badge initially (solo)
-    await expect(page.getByText("×2")).not.toBeVisible();
+    await expect(page.getByTestId("group-badge-0")).not.toBeVisible();
 
     // Click edit pencil on Alice
     await page.getByTestId("edit-person-0").click();
@@ -410,7 +409,7 @@ test.describe("Group claiming units", () => {
     await page.waitForTimeout(1500);
 
     // Should now show ×2 badge
-    await expect(page.getByText("×2").first()).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId("group-badge-0")).toBeVisible({ timeout: 5000 });
 
     // Name should be updated
     await expect(page.getByText("Alice & Bob").first()).toBeVisible();
@@ -461,7 +460,7 @@ test.describe("Group claiming units", () => {
     await page.waitForTimeout(5000);
 
     // Should show ×2 badge
-    await expect(page.getByText("×2").first()).toBeVisible();
+    await expect(page.getByTestId("group-badge-0")).toBeVisible();
 
     // Click edit to change group size back to 1
     await page.getByTestId("edit-person-0").click();
@@ -474,7 +473,7 @@ test.describe("Group claiming units", () => {
     await page.waitForTimeout(1500);
 
     // ×2 badge should be gone
-    await expect(page.getByText("×2")).toHaveCount(0);
+    await expect(page.getByTestId("group-badge-0")).not.toBeVisible();
 
     await page.close();
     await browserCtx.close();

--- a/e2e/group-claiming-units.spec.ts
+++ b/e2e/group-claiming-units.spec.ts
@@ -474,7 +474,7 @@ test.describe("Group claiming units", () => {
     await page.waitForTimeout(1500);
 
     // ×2 badge should be gone
-    await expect(page.getByText("×2")).not.toBeVisible();
+    await expect(page.getByText("×2")).toHaveCount(0);
 
     await page.close();
     await browserCtx.close();

--- a/src/app/[locale]/split/[token]/claim/page.tsx
+++ b/src/app/[locale]/split/[token]/claim/page.tsx
@@ -894,7 +894,7 @@ export default function ClaimPage({
                   <>
                     <span className="flex-1 text-sm font-medium">
                       {person.name}
-                      {person.groupSize > 1 && ` (×${person.groupSize})`}
+                      {person.groupSize > 1 && <span data-testid={`group-badge-${idx}`}>{` (×${person.groupSize})`}</span>}
                       {idx === myPersonIndex && ` ${t("you")}`}
                     </span>
                     <button


### PR DESCRIPTION
## Summary
- Add `data-testid="group-badge-{idx}"` to the group size badge element in the claim page
- Replace all 6 `getByText("×2")` assertions with `getByTestId("group-badge-N")` for reliable, locale-independent matching
- Fixes strict mode violations where `×2` text matched both a person card and switch-person button

## Files Changed
- `src/app/[locale]/split/[token]/claim/page.tsx` — added data-testid to badge span
- `e2e/group-claiming-units.spec.ts` — replaced all text-based badge assertions with test IDs

## Test plan
- [x] All 9 `group-claiming-units.spec.ts` tests pass locally
- [x] "changing group size from 2 to 1 removes badge" (the CI-failing test) now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)