### PR TITLE
fix: auto-run SQL migrations on container startup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,8 @@ npx prisma db push      # apply to dev DB
 npx prisma generate     # regenerate the client
 ```
 
+**Breaking schema changes** (enum conversions, column type changes, data migrations) can't be handled by `prisma db push` alone. For these, add an idempotent `.sql` file in `prisma/migrations/`. The Docker entrypoint runs all `*.sql` files in that directory before `prisma db push`, so they execute automatically on container startup. Name the file descriptively (e.g., `guest_split_status_enum.sql`) and make it safe to re-run.
+
 ### Adding a tRPC route
 
 Routers live in `src/server/trpc/routers/`. Add your procedure there and wire it into `src/server/trpc/router.ts`.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,35 @@ You can also skip the manual copy and paste the raw template URL into Unraid's t
 docker compose exec sharetab su-exec postgres pg_dump -U sharetab sharetab > backup.sql
 ```
 
+## Upgrading
+
+When upgrading to a new ShareTab version, pull the latest image and recreate the container:
+
+```bash
+cd docker
+docker compose pull
+docker compose up -d
+```
+
+The entrypoint automatically runs any SQL migration files in `prisma/migrations/` before applying the Prisma schema. Most upgrades are fully automatic.
+
+### Manual migration (v0.7.x → v0.8.0)
+
+Version 0.8.0 added an `updatedAt` column and converted the `status` column from text to an enum on the `GuestSplit` table. If you upgraded the container image but see errors like:
+
+```
+column GuestSplit.updatedAt does not exist
+```
+
+Run the migration manually:
+
+```bash
+docker exec sharetab su-exec postgres psql -U sharetab -d sharetab \
+  -f /app/prisma/migrations/guest_split_status_enum.sql
+```
+
+This is idempotent — safe to run more than once. Future versions include this migration in the entrypoint automatically.
+
 ## Configuration
 
 All configuration is done through environment variables. Copy `.env.example` to `.env` and adjust as needed.

--- a/README.md
+++ b/README.md
@@ -180,20 +180,14 @@ The entrypoint automatically runs any SQL migration files in `prisma/migrations/
 
 ### Manual migration (v0.7.x → v0.8.0)
 
-Version 0.8.0 added an `updatedAt` column and converted the `status` column from text to an enum on the `GuestSplit` table. If you upgraded the container image but see errors like:
-
-```
-column GuestSplit.updatedAt does not exist
-```
-
-Run the migration manually:
+Version 0.8.0 added an `updatedAt` column and converted the `status` column from text to an enum on the `GuestSplit` table. This migration now runs automatically on container startup. If you need to run it manually:
 
 ```bash
-docker exec sharetab su-exec postgres psql -U sharetab -d sharetab \
+docker compose exec sharetab su-exec postgres psql -U sharetab -d sharetab \
   -f /app/prisma/migrations/guest_split_status_enum.sql
 ```
 
-This is idempotent — safe to run more than once. Future versions include this migration in the entrypoint automatically.
+This is idempotent — safe to run more than once.
 
 ## Configuration
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -74,7 +74,7 @@ if [ -d "/app/prisma/migrations" ]; then
   for sqlfile in /app/prisma/migrations/*.sql; do
     [ -f "$sqlfile" ] || continue
     echo "Running migration: $(basename "$sqlfile")..."
-    su-exec postgres psql -U "$DB_USER" -d "$DB_NAME" -f "$sqlfile" 2>&1 || \
+    su-exec postgres psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$sqlfile" 2>&1 || \
       echo "Warning: Migration $(basename "$sqlfile") had errors (may be safe to ignore if already applied)"
   done
 fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -69,6 +69,16 @@ export DATABASE_URL="${DATABASE_URL:-postgresql://$DB_USER:$DB_PASSWORD@localhos
 
 # ── Run Migrations ──────────────────────────────────────────
 
+# Run manual SQL migrations (for changes prisma db push can't handle, e.g. enum conversions)
+if [ -d "/app/prisma/migrations" ]; then
+  for sqlfile in /app/prisma/migrations/*.sql; do
+    [ -f "$sqlfile" ] || continue
+    echo "Running migration: $(basename "$sqlfile")..."
+    su-exec postgres psql -U "$DB_USER" -d "$DB_NAME" -f "$sqlfile" 2>&1 || \
+      echo "Warning: Migration $(basename "$sqlfile") had errors (may be safe to ignore if already applied)"
+  done
+fi
+
 echo "Running database migrations..."
 NODE_PATH=/prisma-cli/node_modules node /prisma-cli/node_modules/prisma/build/index.js db push || \
 echo "Warning: Could not apply schema"


### PR DESCRIPTION
## Summary

- **Entrypoint now runs `prisma/migrations/*.sql` automatically** before `prisma db push` on every container start, handling breaking schema changes (enum conversions, column type changes) that `prisma db push` can't manage safely
- **Added "Upgrading" section to README.md** with general upgrade instructions and a specific manual migration path for v0.7.x → v0.8.0 users hitting the `GuestSplit.updatedAt` error
- **Added migration guidance to CONTRIBUTING.md** so contributors know when and how to write manual SQL migrations

## Context

After pulling v0.8.0, the production container was spamming `column GuestSplit.updatedAt does not exist` errors on every `guest.mySplits` query. The migration SQL existed at `prisma/migrations/guest_split_status_enum.sql` but was never executed — `prisma db push` can't convert a text column to an enum without data loss, so it silently skipped it.

## Test plan

- [x] Ran migration manually against production DB — errors resolved immediately
- [ ] Rebuild Docker image and verify entrypoint runs `guest_split_status_enum.sql` on fresh start
- [ ] Verify idempotency: restart container twice, confirm no migration errors on second run
- [ ] Verify a fresh install (no existing DB) still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)