### PR TITLE
fix: improve e2e test stability and timeouts

### DIFF
--- a/e2e/admin-ai-provider-ui.spec.ts
+++ b/e2e/admin-ai-provider-ui.spec.ts
@@ -8,7 +8,7 @@ async function goToAdminAndWaitForProviderSection(page: Page) {
   await login(page, users.alice.email, users.alice.password);
   await page.goto("/en/admin");
   const section = page.getByTestId("ai-provider-test-section");
-  await expect(section).toBeVisible({ timeout: 15000 });
+  await expect(section).toBeVisible({ timeout: 30000 });
   return section;
 }
 

--- a/e2e/admin-features.spec.ts
+++ b/e2e/admin-features.spec.ts
@@ -35,16 +35,19 @@ test.describe("User suspend/unsuspend", () => {
   test("admin page shows suspend button for non-admin users", async ({
     page,
   }) => {
+    test.setTimeout(60000);
     await login(page, users.alice.email, users.alice.password);
     await page.goto("/en/admin");
 
-    // Look in the User Management section specifically
+    // Wait for User Management table to load with user data
+    await expect(page.getByText("bob@example.com").first()).toBeVisible({ timeout: 30000 });
+
     const userSection = page.locator("section", {
       has: page.getByRole("heading", { name: "User Management" }),
     });
     const bobRow = userSection.locator("tr", {
       hasText: "bob@example.com",
-    });
+    }).first();
     await expect(bobRow).toBeVisible();
     // Should have either suspend or unsuspend button
     const hasSuspend = await bobRow.getByLabel(/^Suspend /).isVisible().catch(() => false);
@@ -435,11 +438,13 @@ test.describe("User impersonation", () => {
     const userSection = page.locator("section", {
       has: page.getByRole("heading", { name: "User Management" }),
     });
+    await expect(userSection).toBeVisible({ timeout: 30000 });
     const bobRow = userSection
       .locator("table")
       .first()
-      .locator("tr", { hasText: "bob@example.com" });
-    await expect(bobRow).toBeVisible();
+      .locator("tr", { hasText: "bob@example.com" })
+      .first();
+    await expect(bobRow).toBeVisible({ timeout: 15000 });
     await expect(bobRow.getByLabel(/^Impersonate /)).toBeVisible();
   });
 

--- a/e2e/admin-i18n.spec.ts
+++ b/e2e/admin-i18n.spec.ts
@@ -12,7 +12,7 @@ const LOCALES = ["en", "es", "fr", "de", "ja", "ko", "zh-CN"] as const;
 async function loginAndGoToAdmin(page: Page, locale: string) {
   await login(page, users.alice.email, users.alice.password);
   await page.goto(`/${locale}/admin`);
-  await page.waitForLoadState("networkidle", { timeout: 15000 }).catch(() => {});
+  await expect(page.getByRole("heading").first()).toBeVisible({ timeout: 15000 });
 }
 
 // ─── English baseline: verify all sections render translated text ─────
@@ -118,8 +118,6 @@ test.describe("Admin i18n — multi-locale rendering", () => {
     test(`[${locale}] no horizontal overflow on admin page`, async ({ page }) => {
       await loginAndGoToAdmin(page, locale);
       await page.setViewportSize({ width: 1280, height: 800 });
-      await page.waitForTimeout(500);
-
       const hasOverflow = await page.evaluate(() => {
         return document.documentElement.scrollWidth > document.documentElement.clientWidth;
       });

--- a/e2e/api-pending-receipts.spec.ts
+++ b/e2e/api-pending-receipts.spec.ts
@@ -105,7 +105,7 @@ test.describe("Pending Receipts with AI", () => {
     });
     const { receiptId } = await uploadRes.json();
 
-    await trpcMutation(owner, "receipts.processReceipt", { receiptId, groupId }, 90000);
+    await trpcMutation(owner, "receipts.processReceipt", { receiptId, groupId }, 120000);
 
     // Save for later
     const saveRes = await trpcMutation(owner, "receipts.saveForLater", {

--- a/e2e/api-receipt-editing.spec.ts
+++ b/e2e/api-receipt-editing.spec.ts
@@ -26,7 +26,7 @@ test.describe("Receipt Item Editing", () => {
       },
     });
     receiptId = (await uploadRes.json()).receiptId;
-    await trpcMutation(ctx, "receipts.processReceipt", { receiptId }, 90000);
+    await trpcMutation(ctx, "receipts.processReceipt", { receiptId }, 120000);
   });
 
   test.afterAll(async () => {

--- a/e2e/api-receipt.spec.ts
+++ b/e2e/api-receipt.spec.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "fs";
 import { users, authedContext, trpcMutation, trpcQuery, trpcResult, trpcError, createTestGroup , FAKE_JPEG } from "./helpers";
 
 const BASE = process.env.BASE_URL || "http://localhost:3001";
-const AI_TIMEOUT = 90000; // 90s for AI processing calls
+const AI_TIMEOUT = 120000; // 120s for AI processing calls
 
 test.describe("Receipt Scanning Pipeline (5.2-5.3)", () => {
   // Set RUN_AI_TESTS=1 to enable AI-dependent tests

--- a/e2e/guest-claiming-ui.spec.ts
+++ b/e2e/guest-claiming-ui.spec.ts
@@ -77,8 +77,9 @@ test.describe("Guest Claiming Session UI", () => {
     // Should see the join form
     await expect(page2.getByTestId("claim-join-form")).toBeVisible({ timeout: 10000 });
 
-    // Bob joins
+    // Bob joins — wait for button to be enabled after form renders
     await page2.getByTestId("claim-name-input").fill("Bob");
+    await expect(page2.getByTestId("claim-join-btn")).toBeEnabled();
     await page2.getByTestId("claim-join-btn").click();
 
     // Should see items

--- a/e2e/guest-claiming-ui.spec.ts
+++ b/e2e/guest-claiming-ui.spec.ts
@@ -25,7 +25,7 @@ test.describe("Guest Claiming Session UI", () => {
     await fileChooser.setFiles(RECEIPT_PATH);
 
     // Wait for processing → people step
-    await expect(page.getByTestId("guest-people-step")).toBeVisible({ timeout: 90000 });
+    await expect(page.getByTestId("guest-people-step")).toBeVisible({ timeout: 120000 });
 
     // Add creator name
     await page.getByTestId("person-input-0").fill("Alice");

--- a/e2e/guest-split-item-ui.spec.ts
+++ b/e2e/guest-split-item-ui.spec.ts
@@ -23,7 +23,7 @@ test.describe("Guest split — item split UI", () => {
     await fileChooser.setFiles(RECEIPT_PATH);
 
     // Wait for processing → people step
-    await expect(page.getByTestId("guest-people-step")).toBeVisible({ timeout: 90000 });
+    await expect(page.getByTestId("guest-people-step")).toBeVisible({ timeout: 120000 });
 
     // === Step 2: Add people ===
     await page.getByTestId("person-input-0").fill("Alice");
@@ -87,7 +87,7 @@ test.describe("Guest split — item split UI", () => {
     ]);
     await fileChooser.setFiles(RECEIPT_PATH);
 
-    await expect(page.getByTestId("guest-people-step")).toBeVisible({ timeout: 90000 });
+    await expect(page.getByTestId("guest-people-step")).toBeVisible({ timeout: 120000 });
     await page.getByTestId("person-input-0").fill("Alice");
     await page.getByTestId("next-assign-btn").click();
     await expect(page.getByTestId("guest-assign-step")).toBeVisible({ timeout: 10000 });

--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -8,6 +8,7 @@ test.describe("i18n Language Switching", () => {
 
     // Open language switcher and pick Spanish
     await page.getByTestId("language-switcher").first().click();
+    await expect(page.getByRole("menuitem", { name: "🇪🇸 Español" })).toBeVisible();
     await page.getByRole("menuitem", { name: "🇪🇸 Español" }).click();
     await page.waitForURL("**/es/login");
 
@@ -20,6 +21,7 @@ test.describe("i18n Language Switching", () => {
 
     // Switch back to English
     await page.getByTestId("language-switcher").first().click();
+    await expect(page.getByRole("menuitem", { name: "🇺🇸 English" })).toBeVisible();
     await page.getByRole("menuitem", { name: "🇺🇸 English" }).click();
     await page.waitForURL("**/en/login");
 
@@ -36,6 +38,7 @@ test.describe("i18n Language Switching", () => {
 
     // Switch to Spanish
     await page.getByTestId("language-switcher").first().click();
+    await expect(page.getByRole("menuitem", { name: "🇪🇸 Español" })).toBeVisible();
     await page.getByRole("menuitem", { name: "🇪🇸 Español" }).click();
     await page.waitForURL("**/es/register");
 
@@ -46,6 +49,7 @@ test.describe("i18n Language Switching", () => {
 
     // Switch back to English
     await page.getByTestId("language-switcher").first().click();
+    await expect(page.getByRole("menuitem", { name: "🇺🇸 English" })).toBeVisible();
     await page.getByRole("menuitem", { name: "🇺🇸 English" }).click();
     await page.waitForURL("**/en/register");
 
@@ -61,6 +65,7 @@ test.describe("i18n Language Switching", () => {
 
     // Click sidebar language switcher
     await page.getByTestId("language-switcher").first().click();
+    await expect(page.getByRole("menuitem", { name: "🇪🇸 Español" })).toBeVisible();
     await page.getByRole("menuitem", { name: "🇪🇸 Español" }).click();
     await page.waitForURL("**/es/dashboard");
 
@@ -72,6 +77,7 @@ test.describe("i18n Language Switching", () => {
 
     // Switch back to English
     await page.getByTestId("language-switcher").first().click();
+    await expect(page.getByRole("menuitem", { name: "🇺🇸 English" })).toBeVisible();
     await page.getByRole("menuitem", { name: "🇺🇸 English" }).click();
     await page.waitForURL("**/en/dashboard");
 

--- a/e2e/ocr-image-receipts.spec.ts
+++ b/e2e/ocr-image-receipts.spec.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "fs";
 import { users, authedContext, trpcMutation, trpcQuery, trpcResult } from "./helpers";
 
 const BASE = process.env.BASE_URL || "http://localhost:3001";
-const OCR_TIMEOUT = 90000;
+const OCR_TIMEOUT = 120000;
 
 type OCRReceiptItem = {
   name: string;

--- a/e2e/ocr-real-receipts.spec.ts
+++ b/e2e/ocr-real-receipts.spec.ts
@@ -4,7 +4,7 @@ import { readFileSync, readdirSync } from "fs";
 import { users, authedContext, trpcMutation, trpcQuery, trpcResult } from "./helpers";
 
 const BASE = process.env.BASE_URL || "http://localhost:3001";
-const OCR_TIMEOUT = 90000;
+const OCR_TIMEOUT = 120000;
 
 /**
  * Real-world receipt OCR tests using two sources:

--- a/e2e/ocr-receipt.spec.ts
+++ b/e2e/ocr-receipt.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "./helpers";
 
 const BASE = process.env.BASE_URL || "http://localhost:3001";
-const OCR_TIMEOUT = 90000; // Tesseract can be slow on first run (downloads WASM + lang data)
+const OCR_TIMEOUT = 120000; // Tesseract can be slow on first run (downloads WASM + lang data)
 
 test.describe("OCR Receipt Scanning", () => {
   test.beforeEach(({}, testInfo) => {
@@ -165,7 +165,7 @@ test.describe("OCR Receipt Scanning", () => {
       await fileInput.setInputFiles(resolve("e2e/test-receipt.png"));
 
       // Wait for processing to complete — should show dollar amounts
-      await expect(page.getByText(/\$\d+\.\d{2}/).first()).toBeVisible({ timeout: 90000 });
+      await expect(page.getByText(/\$\d+\.\d{2}/).first()).toBeVisible({ timeout: 120000 });
     });
 
     test("guest split page uploads and processes receipt", async ({ page }) => {
@@ -177,7 +177,7 @@ test.describe("OCR Receipt Scanning", () => {
       await fileInput.setInputFiles(resolve("e2e/test-receipt.png"));
 
       // After OCR processing, the guest flow advances to "Who's splitting?"
-      await expect(page.getByText("Who's splitting?")).toBeVisible({ timeout: 90000 });
+      await expect(page.getByText("Who's splitting?")).toBeVisible({ timeout: 120000 });
       await expect(page.getByText("Assign Items")).toBeVisible();
     });
   });

--- a/e2e/ocr-receipt.spec.ts
+++ b/e2e/ocr-receipt.spec.ts
@@ -165,7 +165,7 @@ test.describe("OCR Receipt Scanning", () => {
       await fileInput.setInputFiles(resolve("e2e/test-receipt.png"));
 
       // Wait for processing to complete — should show dollar amounts
-      await expect(page.getByText(/\$\d+\.\d{2}/).first()).toBeVisible({ timeout: 120000 });
+      await expect(page.getByText(/\$\d+\.\d{2}/).first()).toBeVisible({ timeout: OCR_TIMEOUT });
     });
 
     test("guest split page uploads and processes receipt", async ({ page }) => {
@@ -177,7 +177,7 @@ test.describe("OCR Receipt Scanning", () => {
       await fileInput.setInputFiles(resolve("e2e/test-receipt.png"));
 
       // After OCR processing, the guest flow advances to "Who's splitting?"
-      await expect(page.getByText("Who's splitting?")).toBeVisible({ timeout: 120000 });
+      await expect(page.getByText("Who's splitting?")).toBeVisible({ timeout: OCR_TIMEOUT });
       await expect(page.getByText("Assign Items")).toBeVisible();
     });
   });

--- a/e2e/ocr-user-receipts.spec.ts
+++ b/e2e/ocr-user-receipts.spec.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "fs";
 import { users, authedContext, trpcMutation, trpcQuery, trpcResult } from "./helpers";
 
 const BASE = process.env.BASE_URL || "http://localhost:3001";
-const OCR_TIMEOUT = 90000;
+const OCR_TIMEOUT = 120000;
 
 /**
  * OCR tests using AI-generated photorealistic receipt images.

--- a/e2e/split-item-ui.spec.ts
+++ b/e2e/split-item-ui.spec.ts
@@ -22,7 +22,7 @@ test.describe("Split Item UI", () => {
     const { receiptId } = await uploadRes.json();
 
     // Process the receipt
-    await trpcMutation(ctx, "receipts.processReceipt", { receiptId, groupId: "cmow2v0up0003kwxdb2z6r5rr" }, 90000);
+    await trpcMutation(ctx, "receipts.processReceipt", { receiptId, groupId: "cmow2v0up0003kwxdb2z6r5rr" }, 120000);
 
     // Update one item to have quantity > 1 so the scissors button appears
     const itemsRes = await trpcQuery(ctx, "receipts.getReceiptItems", { receiptId });
@@ -78,7 +78,7 @@ test.describe("Split Item UI", () => {
       multipart: { file: { name: "sfl-ui.png", mimeType: "image/png", buffer: require("fs").readFileSync(RECEIPT_PATH) } },
     });
     const { receiptId } = await uploadRes.json();
-    await trpcMutation(ctx, "receipts.processReceipt", { receiptId, groupId: "cmow2v0up0003kwxdb2z6r5rr" }, 90000);
+    await trpcMutation(ctx, "receipts.processReceipt", { receiptId, groupId: "cmow2v0up0003kwxdb2z6r5rr" }, 120000);
 
     // Get the items and member IDs
     const itemsRes = await trpcQuery(ctx, "receipts.getReceiptItems", { receiptId });
@@ -155,7 +155,7 @@ test.describe("Split Item UI", () => {
       multipart: { file: { name: "rehydrate-test.png", mimeType: "image/png", buffer: require("fs").readFileSync(RECEIPT_PATH) } },
     });
     const { receiptId } = await uploadRes.json();
-    await trpcMutation(ctx, "receipts.processReceipt", { receiptId, groupId: "cmow2v0up0003kwxdb2z6r5rr" }, 90000);
+    await trpcMutation(ctx, "receipts.processReceipt", { receiptId, groupId: "cmow2v0up0003kwxdb2z6r5rr" }, 120000);
 
     // Get items + alice's ID
     const itemsRes = await trpcQuery(ctx, "receipts.getReceiptItems", { receiptId });

--- a/e2e/split-item-ui.spec.ts
+++ b/e2e/split-item-ui.spec.ts
@@ -5,10 +5,11 @@ import { users, login, navigateToGroup, authedContext, trpcMutation, trpcQuery, 
 const RECEIPT_PATH = resolve("e2e/receipts/coffee-shop.png");
 const BASE = process.env.BASE_URL || "http://localhost:3001";
 
-async function getFirstGroupId(ctx: Awaited<ReturnType<typeof authedContext>>) {
+async function getApartmentGroupId(ctx: Awaited<ReturnType<typeof authedContext>>) {
   const res = await trpcQuery(ctx, "groups.list");
   const groups = await trpcResult(res);
-  return groups[0]?.id;
+  const apartment = groups.find((g: { name: string }) => g.name === "Apartment");
+  return apartment?.id ?? groups[0]?.id;
 }
 
 test.describe("Split Item UI", () => {
@@ -22,7 +23,7 @@ test.describe("Split Item UI", () => {
   test("split button appears on multi-quantity items and splits correctly", async ({ page }) => {
     // Step 1: Upload and process receipt via API (faster + more reliable)
     const ctx = await authedContext(users.alice.email, users.alice.password);
-    const groupId = await getFirstGroupId(ctx);
+    const groupId = await getApartmentGroupId(ctx);
     const uploadRes = await ctx.post(`${BASE}/api/upload`, {
       multipart: { file: { name: "split-ui.png", mimeType: "image/png", buffer: require("fs").readFileSync(RECEIPT_PATH) } },
     });
@@ -81,7 +82,7 @@ test.describe("Split Item UI", () => {
   test("save for later preserves paid-by and assignments when resuming", async ({ page }) => {
     // Step 1: Set up receipt with items via API
     const ctx = await authedContext(users.alice.email, users.alice.password);
-    const groupId = await getFirstGroupId(ctx);
+    const groupId = await getApartmentGroupId(ctx);
     const uploadRes = await ctx.post(`${BASE}/api/upload`, {
       multipart: { file: { name: "sfl-ui.png", mimeType: "image/png", buffer: require("fs").readFileSync(RECEIPT_PATH) } },
     });
@@ -158,7 +159,7 @@ test.describe("Split Item UI", () => {
   test("save for later rehydrates selections without page refresh", async ({ page }) => {
     // API: upload, process, save with paidById + assignments
     const ctx = await authedContext(users.alice.email, users.alice.password);
-    const groupId = await getFirstGroupId(ctx);
+    const groupId = await getApartmentGroupId(ctx);
 
     const uploadRes = await ctx.post(`${BASE}/api/upload`, {
       multipart: { file: { name: "rehydrate-test.png", mimeType: "image/png", buffer: require("fs").readFileSync(RECEIPT_PATH) } },

--- a/e2e/split-item-ui.spec.ts
+++ b/e2e/split-item-ui.spec.ts
@@ -5,6 +5,12 @@ import { users, login, navigateToGroup, authedContext, trpcMutation, trpcQuery, 
 const RECEIPT_PATH = resolve("e2e/receipts/coffee-shop.png");
 const BASE = process.env.BASE_URL || "http://localhost:3001";
 
+async function getFirstGroupId(ctx: Awaited<ReturnType<typeof authedContext>>) {
+  const res = await trpcQuery(ctx, "groups.list");
+  const groups = await trpcResult(res);
+  return groups[0]?.id;
+}
+
 test.describe("Split Item UI", () => {
   test.beforeEach(async ({ page }, testInfo) => {
     if (!process.env.RUN_AI_TESTS)
@@ -16,13 +22,14 @@ test.describe("Split Item UI", () => {
   test("split button appears on multi-quantity items and splits correctly", async ({ page }) => {
     // Step 1: Upload and process receipt via API (faster + more reliable)
     const ctx = await authedContext(users.alice.email, users.alice.password);
+    const groupId = await getFirstGroupId(ctx);
     const uploadRes = await ctx.post(`${BASE}/api/upload`, {
       multipart: { file: { name: "split-ui.png", mimeType: "image/png", buffer: require("fs").readFileSync(RECEIPT_PATH) } },
     });
     const { receiptId } = await uploadRes.json();
 
     // Process the receipt
-    await trpcMutation(ctx, "receipts.processReceipt", { receiptId, groupId: "cmow2v0up0003kwxdb2z6r5rr" }, 120000);
+    await trpcMutation(ctx, "receipts.processReceipt", { receiptId, groupId }, 120000);
 
     // Update one item to have quantity > 1 so the scissors button appears
     const itemsRes = await trpcQuery(ctx, "receipts.getReceiptItems", { receiptId });
@@ -74,11 +81,12 @@ test.describe("Split Item UI", () => {
   test("save for later preserves paid-by and assignments when resuming", async ({ page }) => {
     // Step 1: Set up receipt with items via API
     const ctx = await authedContext(users.alice.email, users.alice.password);
+    const groupId = await getFirstGroupId(ctx);
     const uploadRes = await ctx.post(`${BASE}/api/upload`, {
       multipart: { file: { name: "sfl-ui.png", mimeType: "image/png", buffer: require("fs").readFileSync(RECEIPT_PATH) } },
     });
     const { receiptId } = await uploadRes.json();
-    await trpcMutation(ctx, "receipts.processReceipt", { receiptId, groupId: "cmow2v0up0003kwxdb2z6r5rr" }, 120000);
+    await trpcMutation(ctx, "receipts.processReceipt", { receiptId, groupId }, 120000);
 
     // Get the items and member IDs
     const itemsRes = await trpcQuery(ctx, "receipts.getReceiptItems", { receiptId });
@@ -120,7 +128,7 @@ test.describe("Split Item UI", () => {
     const firstItemId = itemsData.items[0]?.id;
 
     await trpcMutation(saveCtx, "receipts.saveForLater", {
-      groupId: "cmow2v0up0003kwxdb2z6r5rr",
+      groupId,
       receiptId,
       paidById: selectedValue,
       assignments: firstItemId && memberId ? [{ receiptItemId: firstItemId, userIds: [memberId] }] : [],
@@ -150,24 +158,25 @@ test.describe("Split Item UI", () => {
   test("save for later rehydrates selections without page refresh", async ({ page }) => {
     // API: upload, process, save with paidById + assignments
     const ctx = await authedContext(users.alice.email, users.alice.password);
+    const groupId = await getFirstGroupId(ctx);
 
     const uploadRes = await ctx.post(`${BASE}/api/upload`, {
       multipart: { file: { name: "rehydrate-test.png", mimeType: "image/png", buffer: require("fs").readFileSync(RECEIPT_PATH) } },
     });
     const { receiptId } = await uploadRes.json();
-    await trpcMutation(ctx, "receipts.processReceipt", { receiptId, groupId: "cmow2v0up0003kwxdb2z6r5rr" }, 120000);
+    await trpcMutation(ctx, "receipts.processReceipt", { receiptId, groupId }, 120000);
 
     // Get items + alice's ID
     const itemsRes = await trpcQuery(ctx, "receipts.getReceiptItems", { receiptId });
     const data = await trpcResult(itemsRes);
-    const groupRes = await trpcQuery(ctx, "groups.get", { groupId: "cmow2v0up0003kwxdb2z6r5rr" });
+    const groupRes = await trpcQuery(ctx, "groups.get", { groupId });
     const groupData = await trpcResult(groupRes);
     const aliceId = groupData.members.find((m: { user: { email: string } }) => m.user.email === "alice@example.com").user.id;
     const firstItemId = data.items[0]?.id;
 
     // Save via API with paidById + assignment
     await trpcMutation(ctx, "receipts.saveForLater", {
-      groupId: "cmow2v0up0003kwxdb2z6r5rr",
+      groupId,
       receiptId,
       paidById: aliceId,
       assignments: firstItemId ? [{ receiptItemId: firstItemId, userIds: [aliceId] }] : [],


### PR DESCRIPTION
## Summary
- Increase AI/OCR processing timeouts from 90s to 120s across 9 test files
- Fix admin page test flakiness with better waits and `.first()` for strict mode
- Increase admin AI provider section timeout from 15s to 30s

## Root Causes
- OCR receipt processing can exceed 90s under parallel test load
- Admin page sections load data via staggered tRPC queries, need longer waits
- Test user pollution from previous runs pushes seed users off first page of user management table

## Test plan
- [x] `admin-ai-provider-ui` section renders — passes with 30s timeout
- [x] `admin-features` suspend/impersonate button — passes with fresh seed
- [x] All 9 group-claiming-units tests pass
- [x] 482 tests passed in full suite with `RUN_AI_TESTS=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)