### PR TITLE
feat: multi-currency support (Issue #11)

### DIFF
--- a/messages/de/expenses.json
+++ b/messages/de/expenses.json
@@ -24,6 +24,12 @@
     "selectMember": "Mitglied auswählen",
     "backToGroup": "Zurück zur Gruppe",
     "expenseDetails": "Ausgabendetails",
+    "currency": "Währung",
+    "differentCurrencyNote": "Diese Ausgabe ist in {expenseCurrency}, aber die Gruppe verwendet {groupCurrency}. Der Betrag wird automatisch umgerechnet.",
+    "manualRateOverride": "Wechselkurs manuell festlegen",
+    "exchangeRatePlaceholder": "1 {from} = ? {to}",
+    "convertedAmount": "Umgerechnet: {amount}",
+    "autoRateNote": "Der Wechselkurs wird beim Speichern automatisch abgerufen.",
     "unnamed": "Unbenannt"
   },
   "edit": {
@@ -44,6 +50,7 @@
     "category": "Kategorie",
     "unknown": "Unbekannt",
     "deleting": "Löschen...",
+    "exchangeRate": "Kurs: 1 {from} = {rate} {to}",
     "notFound": "Ausgabe nicht gefunden",
     "notFoundDescription": "Diese Ausgabe existiert nicht oder wurde gelöscht.",
     "backToGroup": "Zurück zur Gruppe"

--- a/messages/de/groups.json
+++ b/messages/de/groups.json
@@ -45,6 +45,7 @@
     "title": "Gruppeneinstellungen",
     "name": "Name",
     "currency": "Währung",
+    "currencyChangeWarning": "Die Änderung der Währung wirkt sich nur auf zukünftige Ausgaben aus. Bestehende Ausgaben behalten ihre ursprünglichen Umrechnungskurse.",
     "members": "Mitglieder",
     "addMember": "Mitglied hinzufügen",
     "removeMember": "Entfernen",

--- a/messages/en/expenses.json
+++ b/messages/en/expenses.json
@@ -22,6 +22,12 @@
     "selectMember": "Select member",
     "backToGroup": "Back to group",
     "expenseDetails": "Expense details",
+    "currency": "Currency",
+    "differentCurrencyNote": "This expense is in {expenseCurrency}, but the group uses {groupCurrency}. The amount will be auto-converted.",
+    "manualRateOverride": "Set exchange rate manually",
+    "exchangeRatePlaceholder": "1 {from} = ? {to}",
+    "convertedAmount": "Converted: {amount}",
+    "autoRateNote": "Exchange rate will be fetched automatically when you save.",
     "submit": "Add Expense",
     "submitting": "Adding...",
     "unnamed": "Unnamed"
@@ -44,6 +50,7 @@
     "delete": "Delete",
     "deleteConfirm": "Delete this expense?",
     "deleting": "Deleting...",
+    "exchangeRate": "Rate: 1 {from} = {rate} {to}",
     "notFound": "Expense not found",
     "notFoundDescription": "This expense doesn't exist or has been deleted.",
     "backToGroup": "Back to Group"

--- a/messages/en/groups.json
+++ b/messages/en/groups.json
@@ -46,6 +46,7 @@
     "name": "Name",
     "description": "Description",
     "currency": "Currency",
+    "currencyChangeWarning": "Changing currency only affects future expenses. Existing expenses will keep their original conversion rates.",
     "members": "Members",
     "addMember": "Add member",
     "removeMember": "Remove",

--- a/messages/es/expenses.json
+++ b/messages/es/expenses.json
@@ -22,6 +22,12 @@
     "selectMember": "Seleccionar miembro",
     "backToGroup": "Volver al grupo",
     "expenseDetails": "Detalles del gasto",
+    "currency": "Moneda",
+    "differentCurrencyNote": "Este gasto es en {expenseCurrency}, pero el grupo usa {groupCurrency}. El monto se convertirá automáticamente.",
+    "manualRateOverride": "Establecer tipo de cambio manualmente",
+    "exchangeRatePlaceholder": "1 {from} = ? {to}",
+    "convertedAmount": "Convertido: {amount}",
+    "autoRateNote": "El tipo de cambio se obtendrá automáticamente al guardar.",
     "submit": "Agregar gasto",
     "submitting": "Agregando...",
     "unnamed": "Sin nombre"
@@ -44,6 +50,7 @@
     "delete": "Eliminar",
     "deleteConfirm": "¿Eliminar este gasto?",
     "deleting": "Eliminando...",
+    "exchangeRate": "Tasa: 1 {from} = {rate} {to}",
     "notFound": "Gasto no encontrado",
     "notFoundDescription": "Este gasto no existe o ha sido eliminado.",
     "backToGroup": "Volver al grupo"

--- a/messages/es/groups.json
+++ b/messages/es/groups.json
@@ -46,6 +46,7 @@
     "name": "Nombre",
     "description": "Descripción",
     "currency": "Moneda",
+    "currencyChangeWarning": "Cambiar la moneda solo afecta gastos futuros. Los gastos existentes mantendrán sus tasas de conversión originales.",
     "members": "Miembros",
     "addMember": "Agregar miembro",
     "removeMember": "Eliminar",

--- a/messages/fr/expenses.json
+++ b/messages/fr/expenses.json
@@ -24,6 +24,12 @@
     "selectMember": "Sélectionner un membre",
     "backToGroup": "Retour au groupe",
     "expenseDetails": "Détails de la dépense",
+    "currency": "Devise",
+    "differentCurrencyNote": "Cette dépense est en {expenseCurrency}, mais le groupe utilise {groupCurrency}. Le montant sera converti automatiquement.",
+    "manualRateOverride": "Définir le taux de change manuellement",
+    "exchangeRatePlaceholder": "1 {from} = ? {to}",
+    "convertedAmount": "Converti : {amount}",
+    "autoRateNote": "Le taux de change sera récupéré automatiquement lors de l'enregistrement.",
     "unnamed": "Sans nom"
   },
   "edit": {
@@ -44,6 +50,7 @@
     "category": "Catégorie",
     "unknown": "Inconnu",
     "deleting": "Suppression...",
+    "exchangeRate": "Taux : 1 {from} = {rate} {to}",
     "notFound": "Dépense introuvable",
     "notFoundDescription": "Cette dépense n'existe pas ou a été supprimée.",
     "backToGroup": "Retour au groupe"

--- a/messages/fr/groups.json
+++ b/messages/fr/groups.json
@@ -45,6 +45,7 @@
     "title": "Paramètres du groupe",
     "name": "Nom",
     "currency": "Devise",
+    "currencyChangeWarning": "Le changement de devise n'affecte que les dépenses futures. Les dépenses existantes conserveront leurs taux de conversion d'origine.",
     "members": "Membres",
     "addMember": "Ajouter un membre",
     "removeMember": "Retirer",

--- a/messages/ja/expenses.json
+++ b/messages/ja/expenses.json
@@ -24,6 +24,12 @@
     "selectMember": "メンバーを選択",
     "backToGroup": "グループに戻る",
     "expenseDetails": "経費の詳細",
+    "currency": "通貨",
+    "differentCurrencyNote": "この経費は{expenseCurrency}ですが、グループは{groupCurrency}を使用しています。金額は自動的に換算されます。",
+    "manualRateOverride": "為替レートを手動で設定",
+    "exchangeRatePlaceholder": "1 {from} = ? {to}",
+    "convertedAmount": "換算額: {amount}",
+    "autoRateNote": "保存時に為替レートが自動的に取得されます。",
     "unnamed": "名前なし"
   },
   "edit": {
@@ -44,6 +50,7 @@
     "category": "カテゴリ",
     "unknown": "不明",
     "deleting": "削除中...",
+    "exchangeRate": "レート: 1 {from} = {rate} {to}",
     "notFound": "経費が見つかりません",
     "notFoundDescription": "この経費は存在しないか、削除されました。",
     "backToGroup": "グループに戻る"

--- a/messages/ja/groups.json
+++ b/messages/ja/groups.json
@@ -45,6 +45,7 @@
     "title": "グループ設定",
     "name": "名前",
     "currency": "通貨",
+    "currencyChangeWarning": "通貨の変更は将来の経費にのみ影響します。既存の経費は元の換算レートを維持します。",
     "members": "メンバー",
     "addMember": "メンバーを追加",
     "removeMember": "削除",

--- a/messages/ko/expenses.json
+++ b/messages/ko/expenses.json
@@ -24,6 +24,12 @@
     "selectMember": "멤버 선택",
     "backToGroup": "그룹으로 돌아가기",
     "expenseDetails": "비용 세부 정보",
+    "currency": "통화",
+    "differentCurrencyNote": "이 비용은 {expenseCurrency}이지만 그룹은 {groupCurrency}를 사용합니다. 금액이 자동으로 환산됩니다.",
+    "manualRateOverride": "환율 수동 설정",
+    "exchangeRatePlaceholder": "1 {from} = ? {to}",
+    "convertedAmount": "환산 금액: {amount}",
+    "autoRateNote": "저장 시 환율이 자동으로 가져옵니다.",
     "unnamed": "이름 없음"
   },
   "edit": {
@@ -44,6 +50,7 @@
     "category": "카테고리",
     "unknown": "알 수 없음",
     "deleting": "삭제 중...",
+    "exchangeRate": "환율: 1 {from} = {rate} {to}",
     "notFound": "비용을 찾을 수 없습니다",
     "notFoundDescription": "이 비용은 존재하지 않거나 삭제되었습니다.",
     "backToGroup": "그룹으로 돌아가기"

--- a/messages/ko/groups.json
+++ b/messages/ko/groups.json
@@ -45,6 +45,7 @@
     "title": "그룹 설정",
     "name": "이름",
     "currency": "통화",
+    "currencyChangeWarning": "통화 변경은 향후 비용에만 영향을 미칩니다. 기존 비용은 원래 환율을 유지합니다.",
     "members": "멤버",
     "addMember": "멤버 추가",
     "removeMember": "제거",

--- a/messages/pt-BR/expenses.json
+++ b/messages/pt-BR/expenses.json
@@ -24,6 +24,12 @@
     "selectMember": "Selecionar membro",
     "backToGroup": "Voltar ao grupo",
     "expenseDetails": "Detalhes da despesa",
+    "currency": "Moeda",
+    "differentCurrencyNote": "Esta despesa é em {expenseCurrency}, mas o grupo usa {groupCurrency}. O valor será convertido automaticamente.",
+    "manualRateOverride": "Definir taxa de câmbio manualmente",
+    "exchangeRatePlaceholder": "1 {from} = ? {to}",
+    "convertedAmount": "Convertido: {amount}",
+    "autoRateNote": "A taxa de câmbio será obtida automaticamente ao salvar.",
     "unnamed": "Sem nome"
   },
   "edit": {
@@ -44,6 +50,7 @@
     "category": "Categoria",
     "unknown": "Desconhecido",
     "deleting": "Excluindo...",
+    "exchangeRate": "Taxa: 1 {from} = {rate} {to}",
     "notFound": "Despesa não encontrada",
     "notFoundDescription": "Esta despesa não existe ou foi excluída.",
     "backToGroup": "Voltar ao grupo"

--- a/messages/pt-BR/groups.json
+++ b/messages/pt-BR/groups.json
@@ -45,6 +45,7 @@
     "title": "Configurações do grupo",
     "name": "Nome",
     "currency": "Moeda",
+    "currencyChangeWarning": "A alteração da moeda afeta apenas despesas futuras. As despesas existentes manterão suas taxas de conversão originais.",
     "members": "Membros",
     "addMember": "Adicionar membro",
     "removeMember": "Remover",

--- a/messages/sv/expenses.json
+++ b/messages/sv/expenses.json
@@ -24,6 +24,12 @@
     "selectMember": "Välj medlem",
     "backToGroup": "Tillbaka till gruppen",
     "expenseDetails": "Utgiftsdetaljer",
+    "currency": "Valuta",
+    "differentCurrencyNote": "Denna utgift är i {expenseCurrency}, men gruppen använder {groupCurrency}. Beloppet konverteras automatiskt.",
+    "manualRateOverride": "Ange växelkurs manuellt",
+    "exchangeRatePlaceholder": "1 {from} = ? {to}",
+    "convertedAmount": "Konverterat: {amount}",
+    "autoRateNote": "Växelkursen hämtas automatiskt när du sparar.",
     "unnamed": "Namnlös"
   },
   "edit": {
@@ -44,6 +50,7 @@
     "category": "Kategori",
     "unknown": "Okänd",
     "deleting": "Tar bort...",
+    "exchangeRate": "Kurs: 1 {from} = {rate} {to}",
     "notFound": "Utgift hittades inte",
     "notFoundDescription": "Denna utgift finns inte eller har tagits bort.",
     "backToGroup": "Tillbaka till gruppen"

--- a/messages/sv/groups.json
+++ b/messages/sv/groups.json
@@ -45,6 +45,7 @@
     "title": "Gruppinställningar",
     "name": "Namn",
     "currency": "Valuta",
+    "currencyChangeWarning": "Att ändra valuta påverkar bara framtida utgifter. Befintliga utgifter behåller sina ursprungliga omräkningskurser.",
     "members": "Medlemmar",
     "addMember": "Lägg till medlem",
     "removeMember": "Ta bort",

--- a/messages/zh-CN/expenses.json
+++ b/messages/zh-CN/expenses.json
@@ -24,6 +24,12 @@
     "selectMember": "选择成员",
     "backToGroup": "返回群组",
     "expenseDetails": "支出详情",
+    "currency": "货币",
+    "differentCurrencyNote": "此支出使用{expenseCurrency}，但群组使用{groupCurrency}。金额将自动转换。",
+    "manualRateOverride": "手动设置汇率",
+    "exchangeRatePlaceholder": "1 {from} = ? {to}",
+    "convertedAmount": "换算金额：{amount}",
+    "autoRateNote": "保存时将自动获取汇率。",
     "unnamed": "未命名"
   },
   "edit": {
@@ -44,6 +50,7 @@
     "category": "类别",
     "unknown": "未知",
     "deleting": "删除中...",
+    "exchangeRate": "汇率：1 {from} = {rate} {to}",
     "notFound": "未找到支出",
     "notFoundDescription": "该支出不存在或已被删除。",
     "backToGroup": "返回群组"

--- a/messages/zh-CN/groups.json
+++ b/messages/zh-CN/groups.json
@@ -45,6 +45,7 @@
     "title": "群组设置",
     "name": "名称",
     "currency": "货币",
+    "currencyChangeWarning": "更改货币仅影响未来的支出。现有支出将保留其原始汇率。",
     "members": "成员",
     "addMember": "添加成员",
     "removeMember": "移除",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,8 +148,10 @@ model Expense {
   groupId     String
   title       String
   description String?   @db.Text
-  amount      Int       // total in cents
+  amount      Int       // total in cents (in expense currency)
   currency    String    @default("USD")
+  exchangeRate        Float?  @default(1.0) // rate: 1 unit of expense currency = X units of group currency
+  baseCurrencyAmount  Int?    // amount converted to group currency (cents); null = same currency
   category    String?
   expenseDate DateTime  @default(now())
   splitMode   SplitMode @default(EQUAL)
@@ -264,8 +266,10 @@ model Settlement {
   groupId  String
   fromId   String
   toId     String
-  amount   Int     // cents
+  amount   Int     // cents (in settlement currency)
   currency String  @default("USD")
+  exchangeRate        Float?  @default(1.0) // rate: 1 unit of settlement currency = X units of group currency
+  baseCurrencyAmount  Int?    // amount converted to group currency (cents); null = same currency
   note     String?
 
   group Group @relation(fields: [groupId], references: [id], onDelete: Cascade)

--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/page.tsx
@@ -23,6 +23,7 @@ export default function ExpenseDetailPage({
   const t = useTranslations("expenses");
 
   const expense = trpc.expenses.get.useQuery({ groupId, expenseId });
+  const group = trpc.groups.get.useQuery({ groupId });
   const deleteExpense = trpc.expenses.delete.useMutation({
     onSuccess: () => router.push(`/groups/${groupId}`),
   });
@@ -44,6 +45,8 @@ export default function ExpenseDetailPage({
   }
 
   const e = expense.data;
+  const groupCurrency = group.data?.currency ?? "USD";
+  const isCurrencyConverted = e.baseCurrencyAmount != null && e.currency.toUpperCase() !== groupCurrency.toUpperCase();
 
   return (
     <div className="mx-auto max-w-lg space-y-6">
@@ -57,9 +60,25 @@ export default function ExpenseDetailPage({
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center justify-between">
-            <span>{formatCents(e.amount, e.currency, locale)}</span>
+            <div>
+              <span>{formatCents(e.amount, e.currency, locale)}</span>
+              {isCurrencyConverted && (
+                <span className="ml-2 text-sm font-normal text-muted-foreground">
+                  ({formatCents(e.baseCurrencyAmount!, groupCurrency, locale)})
+                </span>
+              )}
+            </div>
             <Badge variant="secondary">{e.splitMode}</Badge>
           </CardTitle>
+          {isCurrencyConverted && (
+            <p className="text-xs text-muted-foreground">
+              {t("detail.exchangeRate", {
+                rate: e.exchangeRate?.toFixed(4) ?? "1.0000",
+                from: e.currency,
+                to: groupCurrency,
+              })}
+            </p>
+          )}
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="grid grid-cols-2 gap-4 text-sm">

--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/new/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/new/page.tsx
@@ -4,7 +4,8 @@ import { use, useMemo, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { Link, useRouter } from "@/i18n/navigation";
 import { trpc } from "@/lib/trpc";
-import { parseToCents } from "@/lib/money";
+import { parseToCents, formatCents } from "@/lib/money";
+import { COMMON_CURRENCIES } from "@/lib/currencies";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -47,6 +48,14 @@ export default function NewExpensePage({
   const [paidById, setPaidById] = useState("");
   const [splitMode, setSplitMode] = useState<SplitMode>("EQUAL");
   const [shares, setShares] = useState<ShareEntry[]>([]);
+  const [currency, setCurrency] = useState<string>("");
+  const [manualRate, setManualRate] = useState<string>("");
+  const [useManualRate, setUseManualRate] = useState(false);
+
+  // Initialize currency from group when data loads
+  const groupCurrency = group.data?.currency ?? "USD";
+  const effectiveCurrency = currency || groupCurrency;
+  const isDifferentCurrency = effectiveCurrency.toUpperCase() !== groupCurrency.toUpperCase();
 
   const splitModes = useMemo(() => [
     { value: "EQUAL" as SplitMode, label: t("new.splitEqual"), description: t("new.splitEqualDescription") },
@@ -71,6 +80,8 @@ export default function NewExpensePage({
   );
 
   const amountCents = parseToCents(amountStr);
+  const parsedManualRate = parseFloat(manualRate);
+  const manualRateValid = useManualRate && !isNaN(parsedManualRate) && parsedManualRate > 0;
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -80,6 +91,8 @@ export default function NewExpensePage({
       groupId,
       title,
       amount: amountCents,
+      currency: effectiveCurrency,
+      ...(isDifferentCurrency && manualRateValid ? { exchangeRate: parsedManualRate } : {}),
       category: category || undefined,
       paidById,
       splitMode,
@@ -115,19 +128,89 @@ export default function NewExpensePage({
               />
             </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="amount">{t("new.amount")}</Label>
-              <Input
-                id="amount"
-                type="number"
-                step="0.01"
-                min="0.01"
-                placeholder={t("new.amountPlaceholder")}
-                value={amountStr}
-                onChange={(e) => setAmountStr(e.target.value)}
-                required
-              />
+            <div className="grid grid-cols-[1fr_auto] gap-2">
+              <div className="space-y-2">
+                <Label htmlFor="amount">{t("new.amount")}</Label>
+                <Input
+                  id="amount"
+                  type="number"
+                  step="0.01"
+                  min="0.01"
+                  placeholder={t("new.amountPlaceholder")}
+                  value={amountStr}
+                  onChange={(e) => setAmountStr(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="currency">{t("new.currency")}</Label>
+                <select
+                  id="currency"
+                  value={effectiveCurrency}
+                  onChange={(e) => setCurrency(e.target.value)}
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  {COMMON_CURRENCIES.map((c) => (
+                    <option key={c.code} value={c.code}>
+                      {c.code}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </div>
+
+            {isDifferentCurrency && (
+              <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm dark:border-blue-800 dark:bg-blue-950/50">
+                <p className="text-blue-800 dark:text-blue-200">
+                  {t("new.differentCurrencyNote", {
+                    expenseCurrency: effectiveCurrency,
+                    groupCurrency,
+                  })}
+                </p>
+                <div className="mt-2 flex items-center gap-2">
+                  <label className="flex items-center gap-1.5 text-xs text-blue-700 dark:text-blue-300">
+                    <input
+                      type="checkbox"
+                      checked={useManualRate}
+                      onChange={(e) => setUseManualRate(e.target.checked)}
+                      className="rounded"
+                    />
+                    {t("new.manualRateOverride")}
+                  </label>
+                </div>
+                {useManualRate && (
+                  <div className="mt-2">
+                    <Input
+                      type="number"
+                      step="any"
+                      min="0.000001"
+                      placeholder={t("new.exchangeRatePlaceholder", {
+                        from: effectiveCurrency,
+                        to: groupCurrency,
+                      })}
+                      value={manualRate}
+                      onChange={(e) => setManualRate(e.target.value)}
+                    />
+                    {manualRateValid && amountCents > 0 && (
+                      <p className="mt-1 text-xs text-blue-700 dark:text-blue-300">
+                        {t("new.convertedAmount", {
+                          amount: formatCents(
+                            Math.round(amountCents * parsedManualRate),
+                            groupCurrency,
+                            locale
+                          ),
+                        })}
+                      </p>
+                    )}
+                  </div>
+                )}
+                {!useManualRate && (
+                  <p className="mt-1 text-xs text-blue-600 dark:text-blue-400">
+                    {t("new.autoRateNote")}
+                  </p>
+                )}
+              </div>
+            )}
 
             <div className="space-y-2">
               <Label htmlFor="category">{t("new.category")}</Label>
@@ -188,7 +271,7 @@ export default function NewExpensePage({
                   totalCents={amountCents}
                   onChange={setShares}
                   locale={locale}
-                  currency={group.data?.currency}
+                  currency={effectiveCurrency}
                 />
               )}
               {splitMode === "EXACT" && (
@@ -197,7 +280,7 @@ export default function NewExpensePage({
                   totalCents={amountCents}
                   onChange={setShares}
                   locale={locale}
-                  currency={group.data?.currency}
+                  currency={effectiveCurrency}
                 />
               )}
               {splitMode === "PERCENTAGE" && (
@@ -206,7 +289,7 @@ export default function NewExpensePage({
                   totalCents={amountCents}
                   onChange={setShares}
                   locale={locale}
-                  currency={group.data?.currency}
+                  currency={effectiveCurrency}
                 />
               )}
               {splitMode === "SHARES" && (
@@ -215,7 +298,7 @@ export default function NewExpensePage({
                   totalCents={amountCents}
                   onChange={setShares}
                   locale={locale}
-                  currency={group.data?.currency}
+                  currency={effectiveCurrency}
                 />
               )}
             </div>

--- a/src/app/[locale]/(app)/groups/[groupId]/settings/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/settings/page.tsx
@@ -4,6 +4,7 @@ import { use, useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { Link, useRouter } from "@/i18n/navigation";
 import { trpc } from "@/lib/trpc";
+import { COMMON_CURRENCIES } from "@/lib/currencies";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -26,6 +27,7 @@ export default function GroupSettingsPage({
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [currency, setCurrency] = useState("");
   const [placeholderName, setPlaceholderName] = useState("");
   const [editingPlaceholder, setEditingPlaceholder] = useState<string | null>(null);
   const [editingName, setEditingName] = useState("");
@@ -34,6 +36,7 @@ export default function GroupSettingsPage({
     if (group.data) {
       setName(group.data.name);
       setDescription(group.data.description ?? "");
+      setCurrency(group.data.currency);
     }
   }, [group.data]);
 
@@ -90,6 +93,7 @@ export default function GroupSettingsPage({
       groupId,
       name,
       description: description || undefined,
+      currency: currency || undefined,
     });
   }
 
@@ -157,6 +161,26 @@ export default function GroupSettingsPage({
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
               />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="currency">{t("settings.currency")}</Label>
+              <select
+                id="currency"
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value)}
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                {COMMON_CURRENCIES.map((c) => (
+                  <option key={c.code} value={c.code}>
+                    {c.code} - {c.name}
+                  </option>
+                ))}
+              </select>
+              {currency !== group.data?.currency && (
+                <p className="text-xs text-amber-600 dark:text-amber-400">
+                  {t("settings.currencyChangeWarning")}
+                </p>
+              )}
             </div>
             <Button type="submit" disabled={updateGroup.isPending}>
               {updateGroup.isPending ? t("settings.saving") : t("settings.saveChanges")}

--- a/src/lib/currencies.ts
+++ b/src/lib/currencies.ts
@@ -1,0 +1,52 @@
+/**
+ * Common ISO 4217 currencies for the currency selector.
+ * Ordered by global usage / relevance.
+ */
+export const COMMON_CURRENCIES = [
+  { code: "USD", name: "US Dollar", symbol: "$" },
+  { code: "EUR", name: "Euro", symbol: "€" },
+  { code: "GBP", name: "British Pound", symbol: "£" },
+  { code: "JPY", name: "Japanese Yen", symbol: "¥" },
+  { code: "CAD", name: "Canadian Dollar", symbol: "CA$" },
+  { code: "AUD", name: "Australian Dollar", symbol: "A$" },
+  { code: "CHF", name: "Swiss Franc", symbol: "CHF" },
+  { code: "CNY", name: "Chinese Yuan", symbol: "¥" },
+  { code: "SEK", name: "Swedish Krona", symbol: "kr" },
+  { code: "NOK", name: "Norwegian Krone", symbol: "kr" },
+  { code: "DKK", name: "Danish Krone", symbol: "kr" },
+  { code: "NZD", name: "New Zealand Dollar", symbol: "NZ$" },
+  { code: "MXN", name: "Mexican Peso", symbol: "MX$" },
+  { code: "BRL", name: "Brazilian Real", symbol: "R$" },
+  { code: "KRW", name: "South Korean Won", symbol: "₩" },
+  { code: "INR", name: "Indian Rupee", symbol: "₹" },
+  { code: "HKD", name: "Hong Kong Dollar", symbol: "HK$" },
+  { code: "SGD", name: "Singapore Dollar", symbol: "S$" },
+  { code: "TWD", name: "New Taiwan Dollar", symbol: "NT$" },
+  { code: "PLN", name: "Polish Zloty", symbol: "zł" },
+  { code: "THB", name: "Thai Baht", symbol: "฿" },
+  { code: "ZAR", name: "South African Rand", symbol: "R" },
+  { code: "CZK", name: "Czech Koruna", symbol: "Kč" },
+  { code: "ILS", name: "Israeli Shekel", symbol: "₪" },
+  { code: "CLP", name: "Chilean Peso", symbol: "CLP$" },
+  { code: "PHP", name: "Philippine Peso", symbol: "₱" },
+  { code: "COP", name: "Colombian Peso", symbol: "COL$" },
+  { code: "ARS", name: "Argentine Peso", symbol: "ARS$" },
+  { code: "TRY", name: "Turkish Lira", symbol: "₺" },
+  { code: "HUF", name: "Hungarian Forint", symbol: "Ft" },
+  { code: "ISK", name: "Icelandic Krona", symbol: "kr" },
+  { code: "RON", name: "Romanian Leu", symbol: "lei" },
+  { code: "BGN", name: "Bulgarian Lev", symbol: "лв" },
+  { code: "HRK", name: "Croatian Kuna", symbol: "kn" },
+  { code: "IDR", name: "Indonesian Rupiah", symbol: "Rp" },
+  { code: "MYR", name: "Malaysian Ringgit", symbol: "RM" },
+] as const;
+
+export type CurrencyCode = (typeof COMMON_CURRENCIES)[number]["code"];
+
+/**
+ * Get the display label for a currency code.
+ */
+export function getCurrencyLabel(code: string): string {
+  const found = COMMON_CURRENCIES.find((c) => c.code === code);
+  return found ? `${found.code} - ${found.name}` : code;
+}

--- a/src/server/lib/balance-calculator.test.ts
+++ b/src/server/lib/balance-calculator.test.ts
@@ -441,3 +441,199 @@ describe("computeBalances + simplifyDebts integration", () => {
     expect(debts).toHaveLength(0);
   });
 });
+
+// ── Multi-currency: computeBalances with baseCurrencyAmount ──
+
+describe("computeBalances with multi-currency (baseCurrencyAmount)", () => {
+  test("uses baseCurrencyAmount for payer credit when set", () => {
+    // Expense: 100 EUR (= 110 USD at 1.1 rate), split between Alice and Bob
+    const balances = computeBalances(
+      [
+        {
+          paidById: "alice",
+          amount: 10000, // 100 EUR in cents
+          baseCurrencyAmount: 11000, // 110 USD in cents
+          shares: [
+            { userId: "alice", amount: 5000 },
+            { userId: "bob", amount: 5000 },
+          ],
+        },
+      ],
+      []
+    );
+
+    const alice = balances.find((b) => b.userId === "alice")!;
+    const bob = balances.find((b) => b.userId === "bob")!;
+
+    // Alice paid 110 USD (baseCurrencyAmount), owes 55 USD (scaled from 50 EUR)
+    expect(alice.paid).toBe(11000);
+    expect(alice.owes).toBe(5500);
+    expect(alice.net).toBe(5500);
+
+    // Bob paid 0, owes 55 USD (scaled from 50 EUR)
+    expect(bob.paid).toBe(0);
+    expect(bob.owes).toBe(5500);
+    expect(bob.net).toBe(-5500);
+  });
+
+  test("scales shares proportionally with rounding remainder on last share", () => {
+    // 100 EUR at 1.1 = 110 USD, split 3 ways (33.33 EUR each)
+    // Scaled: 33.33 * 1.1 = 36.67 -> 3667 cents each, but 3667*3 = 11001 != 11000
+    // Last share should get the remainder
+    const balances = computeBalances(
+      [
+        {
+          paidById: "alice",
+          amount: 10000,
+          baseCurrencyAmount: 11000,
+          shares: [
+            { userId: "alice", amount: 3334 },
+            { userId: "bob", amount: 3333 },
+            { userId: "charlie", amount: 3333 },
+          ],
+        },
+      ],
+      []
+    );
+
+    // Sum of all owes should equal baseCurrencyAmount
+    const totalOwes = balances.reduce((sum, b) => sum + b.owes, 0);
+    expect(totalOwes).toBe(11000);
+
+    // Net should sum to 0
+    const netSum = balances.reduce((sum, b) => sum + b.net, 0);
+    expect(netSum).toBe(0);
+  });
+
+  test("null baseCurrencyAmount falls back to amount (backwards compatible)", () => {
+    const balances = computeBalances(
+      [
+        {
+          paidById: "alice",
+          amount: 1000,
+          baseCurrencyAmount: null,
+          shares: [
+            { userId: "alice", amount: 500 },
+            { userId: "bob", amount: 500 },
+          ],
+        },
+      ],
+      []
+    );
+
+    const alice = balances.find((b) => b.userId === "alice")!;
+    expect(alice.paid).toBe(1000);
+    expect(alice.owes).toBe(500);
+    expect(alice.net).toBe(500);
+  });
+
+  test("undefined baseCurrencyAmount falls back to amount (backwards compatible)", () => {
+    const balances = computeBalances(
+      [
+        {
+          paidById: "alice",
+          amount: 1000,
+          // baseCurrencyAmount not set at all
+          shares: [
+            { userId: "alice", amount: 500 },
+            { userId: "bob", amount: 500 },
+          ],
+        },
+      ],
+      []
+    );
+
+    const alice = balances.find((b) => b.userId === "alice")!;
+    expect(alice.paid).toBe(1000);
+    expect(alice.net).toBe(500);
+  });
+
+  test("settlement with baseCurrencyAmount uses converted amount", () => {
+    // Settlement: Bob pays Alice 50 EUR (= 55 USD)
+    const balances = computeBalances(
+      [],
+      [
+        {
+          fromId: "bob",
+          toId: "alice",
+          amount: 5000, // 50 EUR
+          baseCurrencyAmount: 5500, // 55 USD
+        },
+      ]
+    );
+
+    const bob = balances.find((b) => b.userId === "bob")!;
+    const alice = balances.find((b) => b.userId === "alice")!;
+
+    expect(bob.paid).toBe(5500); // Uses baseCurrencyAmount
+    expect(alice.owes).toBe(5500);
+  });
+
+  test("mixed single-currency and multi-currency expenses", () => {
+    const balances = computeBalances(
+      [
+        // USD expense (no conversion) - $100 split 2 ways
+        {
+          paidById: "alice",
+          amount: 10000,
+          shares: [
+            { userId: "alice", amount: 5000 },
+            { userId: "bob", amount: 5000 },
+          ],
+        },
+        // EUR expense converted to USD - 50 EUR = 55 USD, split 2 ways
+        {
+          paidById: "bob",
+          amount: 5000,
+          baseCurrencyAmount: 5500,
+          shares: [
+            { userId: "alice", amount: 2500 },
+            { userId: "bob", amount: 2500 },
+          ],
+        },
+      ],
+      []
+    );
+
+    const alice = balances.find((b) => b.userId === "alice")!;
+    const bob = balances.find((b) => b.userId === "bob")!;
+
+    // Alice: paid 10000 USD, owes 5000 + 2750 (scaled) = 7750
+    expect(alice.paid).toBe(10000);
+    expect(alice.owes).toBe(7750);
+    expect(alice.net).toBe(2250);
+
+    // Bob: paid 5500 USD (converted), owes 5000 + 2750 (scaled) = 7750
+    expect(bob.paid).toBe(5500);
+    expect(bob.owes).toBe(7750);
+    expect(bob.net).toBe(-2250);
+
+    // Net sums to zero
+    expect(alice.net + bob.net).toBe(0);
+  });
+
+  test("baseCurrencyAmount equal to amount does not trigger scaling", () => {
+    // Edge case: baseCurrencyAmount set but equals amount (same currency recorded with explicit rate)
+    const balances = computeBalances(
+      [
+        {
+          paidById: "alice",
+          amount: 1000,
+          baseCurrencyAmount: 1000,
+          shares: [
+            { userId: "alice", amount: 500 },
+            { userId: "bob", amount: 500 },
+          ],
+        },
+      ],
+      []
+    );
+
+    const alice = balances.find((b) => b.userId === "alice")!;
+    const bob = balances.find((b) => b.userId === "bob")!;
+
+    expect(alice.paid).toBe(1000);
+    expect(alice.owes).toBe(500);
+    expect(bob.owes).toBe(500);
+  });
+});

--- a/src/server/lib/balance-calculator.ts
+++ b/src/server/lib/balance-calculator.ts
@@ -19,6 +19,8 @@ export type SimplifiedDebt = {
 export type Expense = {
   paidById: string;
   amount: number;
+  /** Amount in group currency (cents). When set, used instead of amount for balance math. */
+  baseCurrencyAmount?: number | null;
   shares: { userId: string; amount: number }[];
 };
 
@@ -26,6 +28,8 @@ export type Settlement = {
   fromId: string;
   toId: string;
   amount: number;
+  /** Amount in group currency (cents). When set, used instead of amount for balance math. */
+  baseCurrencyAmount?: number | null;
 };
 
 /**
@@ -87,19 +91,40 @@ export function computeBalances(
 
   for (const expense of expenses) {
     const payer = getOrCreate(expense.paidById);
-    payer.paid += expense.amount;
+    const effectiveAmount = expense.baseCurrencyAmount ?? expense.amount;
+    payer.paid += effectiveAmount;
 
-    for (const share of expense.shares) {
-      const member = getOrCreate(share.userId);
-      member.owes += share.amount;
+    // If currency was converted, scale each share proportionally
+    if (expense.baseCurrencyAmount != null && expense.baseCurrencyAmount !== expense.amount) {
+      const ratio = expense.baseCurrencyAmount / expense.amount;
+      let distributed = 0;
+      const scaledShares = expense.shares.map((share, i) => {
+        if (i === expense.shares.length - 1) {
+          // Last share gets the remainder to avoid rounding drift
+          return { userId: share.userId, amount: effectiveAmount - distributed };
+        }
+        const scaled = Math.round(share.amount * ratio);
+        distributed += scaled;
+        return { userId: share.userId, amount: scaled };
+      });
+      for (const share of scaledShares) {
+        const member = getOrCreate(share.userId);
+        member.owes += share.amount;
+      }
+    } else {
+      for (const share of expense.shares) {
+        const member = getOrCreate(share.userId);
+        member.owes += share.amount;
+      }
     }
   }
 
   for (const settlement of settlements) {
     const from = getOrCreate(settlement.fromId);
     const to = getOrCreate(settlement.toId);
-    from.paid += settlement.amount;
-    to.owes += settlement.amount;
+    const effectiveAmount = settlement.baseCurrencyAmount ?? settlement.amount;
+    from.paid += effectiveAmount;
+    to.owes += effectiveAmount;
   }
 
   for (const b of balanceMap.values()) {

--- a/src/server/lib/exchange-rates.test.ts
+++ b/src/server/lib/exchange-rates.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { getExchangeRate, convertCents, clearRateCache } from "./exchange-rates";
+
+describe("convertCents", () => {
+  test("converts cents with exchange rate", () => {
+    // 1000 cents USD * 0.92 EUR/USD = 920 cents EUR
+    expect(convertCents(1000, 0.92)).toBe(920);
+  });
+
+  test("rounds to nearest cent", () => {
+    // 1000 cents * 1.234 = 1234.0 (no rounding needed)
+    expect(convertCents(1000, 1.234)).toBe(1234);
+    // 999 cents * 1.234 = 1232.766 → 1233
+    expect(convertCents(999, 1.234)).toBe(1233);
+  });
+
+  test("handles rate of 1.0 (same currency)", () => {
+    expect(convertCents(5000, 1.0)).toBe(5000);
+  });
+
+  test("handles very small amounts", () => {
+    expect(convertCents(1, 0.5)).toBe(1); // Math.round(0.5) = 1 in JS
+  });
+
+  test("handles zero", () => {
+    expect(convertCents(0, 1.5)).toBe(0);
+  });
+});
+
+describe("getExchangeRate", () => {
+  beforeEach(() => {
+    clearRateCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("returns 1.0 for same currency", async () => {
+    const rate = await getExchangeRate("USD", "USD");
+    expect(rate).toBe(1.0);
+  });
+
+  test("returns 1.0 for same currency (case insensitive)", async () => {
+    const rate = await getExchangeRate("usd", "USD");
+    expect(rate).toBe(1.0);
+  });
+
+  test("fetches rate from API successfully", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ rates: { EUR: 0.92 } }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const rate = await getExchangeRate("USD", "EUR");
+    expect(rate).toBe(0.92);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toContain("from=USD&to=EUR");
+  });
+
+  test("uses cached rate on second call", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ rates: { EUR: 0.92 } }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const rate1 = await getExchangeRate("USD", "EUR");
+    const rate2 = await getExchangeRate("USD", "EUR");
+    expect(rate1).toBe(0.92);
+    expect(rate2).toBe(0.92);
+    // Should only fetch once due to cache
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses date in URL for historical rates", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ rates: { GBP: 0.78 } }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const rate = await getExchangeRate("USD", "GBP", "2025-01-15");
+    expect(rate).toBe(0.78);
+    expect(mockFetch.mock.calls[0][0]).toContain("2025-01-15");
+  });
+
+  test("returns null on API error", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const rate = await getExchangeRate("USD", "EUR");
+    expect(rate).toBeNull();
+  });
+
+  test("returns null on network failure", async () => {
+    const mockFetch = vi.fn().mockRejectedValueOnce(new Error("Network error"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const rate = await getExchangeRate("USD", "EUR");
+    expect(rate).toBeNull();
+  });
+
+  test("returns null for invalid rate data", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ rates: {} }), // missing target currency
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const rate = await getExchangeRate("USD", "XYZ");
+    expect(rate).toBeNull();
+  });
+});

--- a/src/server/lib/exchange-rates.ts
+++ b/src/server/lib/exchange-rates.ts
@@ -1,0 +1,96 @@
+/**
+ * Exchange rate fetcher using frankfurter.app (free, no API key, ECB data).
+ * Caches rates in memory with a configurable TTL.
+ */
+
+const FRANKFURTER_BASE = "https://api.frankfurter.app";
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+type CacheEntry = {
+  rate: number;
+  fetchedAt: number;
+};
+
+// Cache key format: "FROM:TO:DATE" where DATE is YYYY-MM-DD or "latest"
+const rateCache = new Map<string, CacheEntry>();
+
+function cacheKey(from: string, to: string, date?: string): string {
+  return `${from}:${to}:${date ?? "latest"}`;
+}
+
+/**
+ * Fetch the exchange rate for converting `from` currency to `to` currency.
+ *
+ * @param from - ISO 4217 currency code (e.g., "EUR")
+ * @param to - ISO 4217 currency code (e.g., "USD")
+ * @param date - Optional YYYY-MM-DD date for historical rate. Omit for latest.
+ * @returns The exchange rate (1 unit of `from` = rate units of `to`), or null if fetch fails.
+ */
+export async function getExchangeRate(
+  from: string,
+  to: string,
+  date?: string
+): Promise<number | null> {
+  // Same currency = 1:1
+  if (from.toUpperCase() === to.toUpperCase()) {
+    return 1.0;
+  }
+
+  const key = cacheKey(from.toUpperCase(), to.toUpperCase(), date);
+
+  // Check cache
+  const cached = rateCache.get(key);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.rate;
+  }
+
+  try {
+    const endpoint = date ? `${FRANKFURTER_BASE}/${date}` : `${FRANKFURTER_BASE}/latest`;
+    const url = `${endpoint}?from=${encodeURIComponent(from.toUpperCase())}&to=${encodeURIComponent(to.toUpperCase())}`;
+
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(5000), // 5s timeout
+    });
+
+    if (!response.ok) {
+      console.error(`[exchange-rates] Frankfurter API returned ${response.status} for ${key}`);
+      return null;
+    }
+
+    const data = (await response.json()) as {
+      rates: Record<string, number>;
+    };
+
+    const rate = data.rates[to.toUpperCase()];
+    if (typeof rate !== "number" || !isFinite(rate) || rate <= 0) {
+      console.error(`[exchange-rates] Invalid rate for ${key}:`, data);
+      return null;
+    }
+
+    // Cache the result
+    rateCache.set(key, { rate, fetchedAt: Date.now() });
+
+    return rate;
+  } catch (error) {
+    console.error(`[exchange-rates] Failed to fetch rate for ${key}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Convert an amount in cents from one currency to another.
+ *
+ * @param amountCents - Amount in cents in the source currency
+ * @param exchangeRate - The exchange rate (1 unit source = rate units target)
+ * @returns Amount in cents in the target currency, rounded to nearest cent
+ */
+export function convertCents(amountCents: number, exchangeRate: number): number {
+  return Math.round(amountCents * exchangeRate);
+}
+
+/**
+ * Clear the rate cache. Useful for testing.
+ */
+export function clearRateCache(): void {
+  rateCache.clear();
+}

--- a/src/server/trpc/routers/balances.ts
+++ b/src/server/trpc/routers/balances.ts
@@ -12,12 +12,13 @@ export const balancesRouter = createTRPCRouter({
           select: {
             paidById: true,
             amount: true,
+            baseCurrencyAmount: true,
             shares: { select: { userId: true, amount: true } },
           },
         }),
         ctx.db.settlement.findMany({
           where: { groupId: input.groupId },
-          select: { fromId: true, toId: true, amount: true },
+          select: { fromId: true, toId: true, amount: true, baseCurrencyAmount: true },
         }),
       ]);
 
@@ -34,12 +35,13 @@ export const balancesRouter = createTRPCRouter({
           select: {
             paidById: true,
             amount: true,
+            baseCurrencyAmount: true,
             shares: { select: { userId: true, amount: true } },
           },
         }),
         ctx.db.settlement.findMany({
           where: { groupId: input.groupId },
-          select: { fromId: true, toId: true, amount: true },
+          select: { fromId: true, toId: true, amount: true, baseCurrencyAmount: true },
         }),
       ]);
 
@@ -56,11 +58,12 @@ export const balancesRouter = createTRPCRouter({
           select: {
             paidById: true,
             amount: true,
+            baseCurrencyAmount: true,
             shares: { select: { userId: true, amount: true } },
           },
         },
         settlements: {
-          select: { fromId: true, toId: true, amount: true },
+          select: { fromId: true, toId: true, amount: true, baseCurrencyAmount: true },
         },
         members: {
           select: { user: { select: { id: true, name: true, venmoUsername: true } } },
@@ -147,11 +150,12 @@ export const balancesRouter = createTRPCRouter({
           select: {
             paidById: true,
             amount: true,
+            baseCurrencyAmount: true,
             shares: { select: { userId: true, amount: true } },
           },
         },
         settlements: {
-          select: { fromId: true, toId: true, amount: true },
+          select: { fromId: true, toId: true, amount: true, baseCurrencyAmount: true },
         },
       },
     });
@@ -170,12 +174,29 @@ export const balancesRouter = createTRPCRouter({
       let owes = 0;
 
       for (const expense of group.expenses) {
+        const effectiveAmount = expense.baseCurrencyAmount ?? expense.amount;
         if (expense.paidById === ctx.user.id) {
-          paid += expense.amount;
+          paid += effectiveAmount;
         }
-        for (const share of expense.shares) {
-          if (share.userId === ctx.user.id) {
-            owes += share.amount;
+        // Scale shares proportionally if currency was converted
+        if (expense.baseCurrencyAmount != null && expense.baseCurrencyAmount !== expense.amount) {
+          const ratio = expense.baseCurrencyAmount / expense.amount;
+          let distributed = 0;
+          for (let i = 0; i < expense.shares.length; i++) {
+            const share = expense.shares[i];
+            const scaledAmount = i === expense.shares.length - 1
+              ? effectiveAmount - distributed
+              : Math.round(share.amount * ratio);
+            distributed += scaledAmount;
+            if (share.userId === ctx.user.id) {
+              owes += scaledAmount;
+            }
+          }
+        } else {
+          for (const share of expense.shares) {
+            if (share.userId === ctx.user.id) {
+              owes += share.amount;
+            }
           }
         }
       }
@@ -185,8 +206,9 @@ export const balancesRouter = createTRPCRouter({
       // e.g., if Alice pays Bob $50, Alice's paid goes up and Bob's owes goes up,
       // reducing Bob's net balance (what others owe him) by $50.
       for (const settlement of group.settlements) {
-        if (settlement.fromId === ctx.user.id) paid += settlement.amount;
-        if (settlement.toId === ctx.user.id) owes += settlement.amount;
+        const effectiveAmount = settlement.baseCurrencyAmount ?? settlement.amount;
+        if (settlement.fromId === ctx.user.id) paid += effectiveAmount;
+        if (settlement.toId === ctx.user.id) owes += effectiveAmount;
       }
 
       const net = paid - owes;

--- a/src/server/trpc/routers/expenses.ts
+++ b/src/server/trpc/routers/expenses.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, groupMemberProcedure } from "../init";
 import { SplitMode } from "@/generated/prisma/client";
+import { getExchangeRate, convertCents } from "../../lib/exchange-rates";
 
 const expenseShareSchema = z.object({
   userId: z.string(),
@@ -70,6 +71,7 @@ export const expensesRouter = createTRPCRouter({
         description: z.string().max(1000).optional(),
         amount: z.number().int().positive(),
         currency: z.string().length(3).default("USD"),
+        exchangeRate: z.number().positive().optional(), // manual override
         category: z.string().max(50).optional(),
         expenseDate: z.string().datetime().optional(),
         paidById: z.string(),
@@ -82,7 +84,7 @@ export const expensesRouter = createTRPCRouter({
       // Block expenses on archived groups
       const group = await ctx.db.group.findUnique({
         where: { id: input.groupId },
-        select: { archivedAt: true },
+        select: { archivedAt: true, currency: true },
       });
       if (group?.archivedAt) {
         throw new TRPCError({
@@ -111,13 +113,40 @@ export const expensesRouter = createTRPCRouter({
         });
       }
 
-      // Validate shares sum equals total
+      // Validate shares sum equals total (in expense's original currency)
       const sharesSum = input.shares.reduce((sum, s) => sum + s.amount, 0);
       if (sharesSum !== input.amount) {
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: `Shares sum (${sharesSum}) does not equal expense amount (${input.amount})`,
         });
+      }
+
+      // Currency conversion: compute base currency amount if currencies differ
+      let exchangeRate: number | null = null;
+      let baseCurrencyAmount: number | null = null;
+
+      const groupCurrency = group?.currency ?? "USD";
+      if (input.currency.toUpperCase() !== groupCurrency.toUpperCase()) {
+        if (input.exchangeRate) {
+          // Manual override
+          exchangeRate = input.exchangeRate;
+        } else {
+          // Auto-fetch from frankfurter.app
+          const dateStr = input.expenseDate
+            ? input.expenseDate.slice(0, 10) // YYYY-MM-DD from ISO string
+            : undefined;
+          exchangeRate = await getExchangeRate(input.currency, groupCurrency, dateStr);
+        }
+
+        if (exchangeRate === null) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Could not fetch exchange rate. Please provide a manual rate or try again.",
+          });
+        }
+
+        baseCurrencyAmount = convertCents(input.amount, exchangeRate);
       }
 
       const expense = await ctx.db.expense.create({
@@ -127,6 +156,8 @@ export const expensesRouter = createTRPCRouter({
           description: input.description,
           amount: input.amount,
           currency: input.currency,
+          exchangeRate: exchangeRate ?? 1.0,
+          baseCurrencyAmount,
           category: input.category,
           expenseDate: input.expenseDate ? new Date(input.expenseDate) : new Date(),
           paidById: input.paidById,
@@ -168,6 +199,8 @@ export const expensesRouter = createTRPCRouter({
         title: z.string().min(1).max(200).optional(),
         description: z.string().max(1000).optional(),
         amount: z.number().int().positive().optional(),
+        currency: z.string().length(3).optional(),
+        exchangeRate: z.number().positive().optional(), // manual override
         category: z.string().max(50).optional(),
         expenseDate: z.string().datetime().optional(),
         paidById: z.string().optional(),
@@ -179,7 +212,7 @@ export const expensesRouter = createTRPCRouter({
       // Block updates on archived groups
       const groupCheck = await ctx.db.group.findUnique({
         where: { id: input.groupId },
-        select: { archivedAt: true },
+        select: { archivedAt: true, currency: true },
       });
       if (groupCheck?.archivedAt) {
         throw new TRPCError({
@@ -216,7 +249,7 @@ export const expensesRouter = createTRPCRouter({
         }
       }
 
-      const { groupId, expenseId, shares, ...data } = input;
+      const { groupId, expenseId, shares, currency: inputCurrency, exchangeRate: inputExchangeRate, ...data } = input;
 
       if (shares) {
         // Validate all share userIds are group members
@@ -241,6 +274,37 @@ export const expensesRouter = createTRPCRouter({
         }
       }
 
+      // Recompute currency conversion if currency or amount changed
+      const effectiveCurrency = inputCurrency ?? existing.currency;
+      const effectiveAmount = data.amount ?? existing.amount;
+      const groupCurrency = groupCheck?.currency ?? "USD";
+      let newExchangeRate: number | null = existing.exchangeRate;
+      let newBaseCurrencyAmount: number | null = existing.baseCurrencyAmount;
+
+      if (effectiveCurrency.toUpperCase() !== groupCurrency.toUpperCase()) {
+        if (inputExchangeRate) {
+          newExchangeRate = inputExchangeRate;
+        } else if (inputCurrency || data.amount) {
+          // Currency or amount changed -- re-fetch rate
+          const dateStr = (data.expenseDate ?? existing.expenseDate.toISOString()).slice(0, 10);
+          const fetched = await getExchangeRate(effectiveCurrency, groupCurrency, dateStr);
+          if (fetched === null) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: "Could not fetch exchange rate. Please provide a manual rate or try again.",
+            });
+          }
+          newExchangeRate = fetched;
+        }
+        newBaseCurrencyAmount = newExchangeRate
+          ? convertCents(effectiveAmount, newExchangeRate)
+          : null;
+      } else {
+        // Same currency as group -- clear conversion fields
+        newExchangeRate = 1.0;
+        newBaseCurrencyAmount = null;
+      }
+
       const expense = await ctx.db.$transaction(async (tx) => {
         if (shares) {
           await tx.expenseShare.deleteMany({ where: { expenseId } });
@@ -259,6 +323,9 @@ export const expensesRouter = createTRPCRouter({
           where: { id: expenseId },
           data: {
             ...data,
+            ...(inputCurrency ? { currency: inputCurrency } : {}),
+            exchangeRate: newExchangeRate ?? 1.0,
+            baseCurrencyAmount: newBaseCurrencyAmount,
             ...(data.expenseDate ? { expenseDate: new Date(data.expenseDate) } : {}),
           },
           include: { shares: true },

--- a/src/server/trpc/routers/settlements.ts
+++ b/src/server/trpc/routers/settlements.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, groupMemberProcedure } from "../init";
+import { getExchangeRate, convertCents } from "../../lib/exchange-rates";
 
 export const settlementsRouter = createTRPCRouter({
   list: groupMemberProcedure
@@ -38,6 +39,7 @@ export const settlementsRouter = createTRPCRouter({
         toId: z.string(),
         amount: z.number().int().positive(),
         currency: z.string().length(3).default("USD"),
+        exchangeRate: z.number().positive().optional(), // manual override
         note: z.string().max(500).optional(),
       })
     )
@@ -47,7 +49,7 @@ export const settlementsRouter = createTRPCRouter({
       // Block settlements on archived groups
       const group = await ctx.db.group.findUnique({
         where: { id: input.groupId },
-        select: { archivedAt: true },
+        select: { archivedAt: true, currency: true },
       });
       if (group?.archivedAt) {
         throw new TRPCError({
@@ -90,6 +92,28 @@ export const settlementsRouter = createTRPCRouter({
         });
       }
 
+      // Currency conversion: compute base currency amount if currencies differ
+      const groupCurrency = group?.currency ?? "USD";
+      let exchangeRate: number | null = null;
+      let baseCurrencyAmount: number | null = null;
+
+      if (input.currency.toUpperCase() !== groupCurrency.toUpperCase()) {
+        if (input.exchangeRate) {
+          exchangeRate = input.exchangeRate;
+        } else {
+          exchangeRate = await getExchangeRate(input.currency, groupCurrency);
+        }
+
+        if (exchangeRate === null) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Could not fetch exchange rate. Please provide a manual rate or try again.",
+          });
+        }
+
+        baseCurrencyAmount = convertCents(input.amount, exchangeRate);
+      }
+
       const settlement = await ctx.db.settlement.create({
         data: {
           groupId: input.groupId,
@@ -97,6 +121,8 @@ export const settlementsRouter = createTRPCRouter({
           toId: input.toId,
           amount: input.amount,
           currency: input.currency,
+          exchangeRate: exchangeRate ?? 1.0,
+          baseCurrencyAmount,
           note: input.note,
         },
       });


### PR DESCRIPTION
## Summary
- **Schema**: Added `exchangeRate` and `baseCurrencyAmount` fields to `Expense` and `Settlement` models for currency conversion tracking
- **Exchange rate service**: New `src/server/lib/exchange-rates.ts` fetches rates from frankfurter.app (free ECB data) with 1-hour in-memory cache and 5s timeout
- **Balance calculator**: Updated `computeBalances` to use `baseCurrencyAmount` when available, with proportional share scaling and rounding-safe remainder distribution
- **tRPC routers**: Expense create/update and settlement create now auto-fetch exchange rates when currencies differ, with manual override support
- **UI**: Currency selector on Add Expense form, converted amount display on expense detail page, currency setting in group settings with future-only warning
- **i18n**: All 7 new translation keys added to all 9 locales (en, es, sv, fr, de, pt-BR, ja, zh-CN, ko)
- **Tests**: 20 new unit tests for exchange rate service and multi-currency balance calculations (239 total, all passing)

## Test plan
- [x] All 239 unit tests pass (`npm test`)
- [x] i18n lint passes — no missing/extra keys (`npm run lint:i18n`)
- [x] No new ESLint errors introduced
- [ ] Manual: Create a group in USD, add expense in EUR — verify auto-conversion and balance display
- [ ] Manual: Override exchange rate manually — verify stored rate matches override
- [ ] Manual: Change group currency in settings — verify warning shown and existing expenses unaffected
- [ ] Manual: Verify single-currency groups behave identically to before (backwards compatibility)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)