### PR TITLE
fix: add multi-currency support to expense edit page

### DIFF
--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
@@ -4,7 +4,8 @@ import { use, useMemo, useState, useEffect } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { Link, useRouter } from "@/i18n/navigation";
 import { trpc } from "@/lib/trpc";
-import { parseToCents, centsToDecimal } from "@/lib/money";
+import { parseToCents, centsToDecimal, formatCents } from "@/lib/money";
+import { COMMON_CURRENCIES } from "@/lib/currencies";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -55,6 +56,9 @@ export default function EditExpensePage({
   const [paidById, setPaidById] = useState("");
   const [splitMode, setSplitMode] = useState<SplitMode>("EQUAL");
   const [shares, setShares] = useState<ShareEntry[]>([]);
+  const [currency, setCurrency] = useState<string>("");
+  const [manualRate, setManualRate] = useState<string>("");
+  const [useManualRate, setUseManualRate] = useState(false);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
@@ -64,6 +68,7 @@ export default function EditExpensePage({
       setAmountStr(centsToDecimal(e.amount));
       setCategory(e.category ?? "");
       setPaidById(e.paidById);
+      setCurrency(e.currency);
       if (e.splitMode !== "ITEM") {
         setSplitMode(e.splitMode as SplitMode);
       }
@@ -84,6 +89,11 @@ export default function EditExpensePage({
     })) ?? [];
 
   const amountCents = parseToCents(amountStr);
+  const groupCurrency = group.data?.currency ?? "USD";
+  const effectiveCurrency = currency || groupCurrency;
+  const isDifferentCurrency = effectiveCurrency.toUpperCase() !== groupCurrency.toUpperCase();
+  const parsedManualRate = parseFloat(manualRate);
+  const manualRateValid = useManualRate && !isNaN(parsedManualRate) && parsedManualRate > 0;
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -94,6 +104,8 @@ export default function EditExpensePage({
       expenseId,
       title,
       amount: amountCents,
+      currency: effectiveCurrency,
+      ...(isDifferentCurrency && manualRateValid ? { exchangeRate: parsedManualRate } : {}),
       category: category || undefined,
       paidById,
       splitMode,
@@ -155,19 +167,89 @@ export default function EditExpensePage({
               />
             </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="amount">{t("new.amount")}</Label>
-              <Input
-                id="amount"
-                type="number"
-                step="0.01"
-                min="0.01"
-                placeholder={t("new.amountPlaceholder")}
-                value={amountStr}
-                onChange={(e) => setAmountStr(e.target.value)}
-                required
-              />
+            <div className="grid grid-cols-[1fr_auto] gap-2">
+              <div className="space-y-2">
+                <Label htmlFor="amount">{t("new.amount")}</Label>
+                <Input
+                  id="amount"
+                  type="number"
+                  step="0.01"
+                  min="0.01"
+                  placeholder={t("new.amountPlaceholder")}
+                  value={amountStr}
+                  onChange={(e) => setAmountStr(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="currency">{t("new.currency")}</Label>
+                <select
+                  id="currency"
+                  value={effectiveCurrency}
+                  onChange={(e) => setCurrency(e.target.value)}
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  {COMMON_CURRENCIES.map((c) => (
+                    <option key={c.code} value={c.code}>
+                      {c.code}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </div>
+
+            {isDifferentCurrency && (
+              <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm dark:border-blue-800 dark:bg-blue-950/50">
+                <p className="text-blue-800 dark:text-blue-200">
+                  {t("new.differentCurrencyNote", {
+                    expenseCurrency: effectiveCurrency,
+                    groupCurrency,
+                  })}
+                </p>
+                <div className="mt-2 flex items-center gap-2">
+                  <label className="flex items-center gap-1.5 text-xs text-blue-700 dark:text-blue-300">
+                    <input
+                      type="checkbox"
+                      checked={useManualRate}
+                      onChange={(e) => setUseManualRate(e.target.checked)}
+                      className="rounded"
+                    />
+                    {t("new.manualRateOverride")}
+                  </label>
+                </div>
+                {useManualRate && (
+                  <div className="mt-2">
+                    <Input
+                      type="number"
+                      step="any"
+                      min="0.000001"
+                      placeholder={t("new.exchangeRatePlaceholder", {
+                        from: effectiveCurrency,
+                        to: groupCurrency,
+                      })}
+                      value={manualRate}
+                      onChange={(e) => setManualRate(e.target.value)}
+                    />
+                    {manualRateValid && amountCents > 0 && (
+                      <p className="mt-1 text-xs text-blue-700 dark:text-blue-300">
+                        {t("new.convertedAmount", {
+                          amount: formatCents(
+                            Math.round(amountCents * parsedManualRate),
+                            groupCurrency,
+                            locale
+                          ),
+                        })}
+                      </p>
+                    )}
+                  </div>
+                )}
+                {!useManualRate && (
+                  <p className="mt-1 text-xs text-blue-600 dark:text-blue-400">
+                    {t("new.autoRateNote")}
+                  </p>
+                )}
+              </div>
+            )}
 
             <div className="space-y-2">
               <Label htmlFor="category">{t("new.category")}</Label>
@@ -228,7 +310,7 @@ export default function EditExpensePage({
                   totalCents={amountCents}
                   onChange={setShares}
                   locale={locale}
-                  currency={group.data?.currency}
+                  currency={effectiveCurrency}
                 />
               )}
               {splitMode === "EXACT" && (
@@ -237,7 +319,7 @@ export default function EditExpensePage({
                   totalCents={amountCents}
                   onChange={setShares}
                   locale={locale}
-                  currency={group.data?.currency}
+                  currency={effectiveCurrency}
                 />
               )}
               {splitMode === "PERCENTAGE" && (
@@ -246,7 +328,7 @@ export default function EditExpensePage({
                   totalCents={amountCents}
                   onChange={setShares}
                   locale={locale}
-                  currency={group.data?.currency}
+                  currency={effectiveCurrency}
                 />
               )}
               {splitMode === "SHARES" && (
@@ -255,7 +337,7 @@ export default function EditExpensePage({
                   totalCents={amountCents}
                   onChange={setShares}
                   locale={locale}
-                  currency={group.data?.currency}
+                  currency={effectiveCurrency}
                 />
               )}
             </div>

--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
@@ -70,7 +70,7 @@ export default function EditExpensePage({
       setPaidById(e.paidById);
       setCurrency(e.currency);
       const groupCur = group.data.currency;
-      if (e.currency.toUpperCase() !== groupCur.toUpperCase() && e.exchangeRate && e.exchangeRate !== 1) {
+      if (e.currency.toUpperCase() !== groupCur.toUpperCase() && e.exchangeRate) {
         setUseManualRate(true);
         setManualRate(String(e.exchangeRate));
       }

--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
@@ -69,12 +69,17 @@ export default function EditExpensePage({
       setCategory(e.category ?? "");
       setPaidById(e.paidById);
       setCurrency(e.currency);
+      const groupCur = group.data?.currency ?? "USD";
+      if (e.currency.toUpperCase() !== groupCur.toUpperCase() && e.exchangeRate && e.exchangeRate !== 1) {
+        setUseManualRate(true);
+        setManualRate(String(e.exchangeRate));
+      }
       if (e.splitMode !== "ITEM") {
         setSplitMode(e.splitMode as SplitMode);
       }
       setLoaded(true);
     }
-  }, [expense.data, loaded]);
+  }, [expense.data, group.data, loaded]);
 
   const updateExpense = trpc.expenses.update.useMutation({
     onSuccess: () => {

--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
@@ -62,14 +62,14 @@ export default function EditExpensePage({
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
-    if (expense.data && !loaded) {
+    if (expense.data && group.data && !loaded) {
       const e = expense.data;
       setTitle(e.title);
       setAmountStr(centsToDecimal(e.amount));
       setCategory(e.category ?? "");
       setPaidById(e.paidById);
       setCurrency(e.currency);
-      const groupCur = group.data?.currency ?? "USD";
+      const groupCur = group.data.currency;
       if (e.currency.toUpperCase() !== groupCur.toUpperCase() && e.exchangeRate && e.exchangeRate !== 1) {
         setUseManualRate(true);
         setManualRate(String(e.exchangeRate));

--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
@@ -94,6 +94,7 @@ export default function EditExpensePage({
   const isDifferentCurrency = effectiveCurrency.toUpperCase() !== groupCurrency.toUpperCase();
   const parsedManualRate = parseFloat(manualRate);
   const manualRateValid = useManualRate && !isNaN(parsedManualRate) && parsedManualRate > 0;
+  const currencyChanged = effectiveCurrency.toUpperCase() !== (expense.data?.currency ?? "").toUpperCase();
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -104,8 +105,8 @@ export default function EditExpensePage({
       expenseId,
       title,
       amount: amountCents,
-      currency: effectiveCurrency,
-      ...(isDifferentCurrency && manualRateValid ? { exchangeRate: parsedManualRate } : {}),
+      ...(currencyChanged ? { currency: effectiveCurrency } : {}),
+      ...(currencyChanged && isDifferentCurrency && manualRateValid ? { exchangeRate: parsedManualRate } : {}),
       category: category || undefined,
       paidById,
       splitMode,

--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
@@ -106,7 +106,7 @@ export default function EditExpensePage({
       title,
       amount: amountCents,
       ...(currencyChanged ? { currency: effectiveCurrency } : {}),
-      ...(currencyChanged && isDifferentCurrency && manualRateValid ? { exchangeRate: parsedManualRate } : {}),
+      ...(isDifferentCurrency && manualRateValid ? { exchangeRate: parsedManualRate } : {}),
       category: category || undefined,
       paidById,
       splitMode,

--- a/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
+++ b/src/app/[locale]/(app)/groups/[groupId]/expenses/[expenseId]/edit/page.tsx
@@ -192,7 +192,11 @@ export default function EditExpensePage({
                 <select
                   id="currency"
                   value={effectiveCurrency}
-                  onChange={(e) => setCurrency(e.target.value)}
+                  onChange={(e) => {
+                    setCurrency(e.target.value);
+                    setManualRate("");
+                    setUseManualRate(false);
+                  }}
                   className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 >
                   {COMMON_CURRENCIES.map((c) => (


### PR DESCRIPTION
## Summary
- Brings the expense edit page to parity with the new expense page after #149 (multi-currency support)
- Adds currency selector dropdown alongside the amount field
- Adds manual exchange rate override with live converted-amount preview
- Passes the selected currency through to all split mode components

## Context
The edit expense page was missed when multi-currency support shipped in #149. Without this fix, users could set a currency when creating an expense but lost that ability when editing.

## Test plan
- [ ] Edit an expense — verify the currency dropdown appears pre-filled with the expense's currency
- [ ] Change the currency to one different from the group currency — verify the info banner and auto-rate note appear
- [ ] Enable manual rate override, enter a rate — verify the converted amount preview updates
- [ ] Save the edited expense — verify currency and exchange rate persist
- [ ] Verify all four split modes (equal, exact, percentage, shares) display amounts in the selected currency

🤖 Generated with [Claude Code](https://claude.com/claude-code)