### PR TITLE
fix: stabilize flaky admin-i18n heading test

### DIFF
--- a/e2e/admin-i18n.spec.ts
+++ b/e2e/admin-i18n.spec.ts
@@ -126,13 +126,13 @@ test.describe("Admin i18n — multi-locale rendering", () => {
 
     test(`[${locale}] admin sections have no empty headings`, async ({ page }) => {
       await loginAndGoToAdmin(page, locale);
+      await page.waitForLoadState("networkidle");
 
-      const headings = page.getByRole("heading");
-      const count = await headings.count();
-      expect(count).toBeGreaterThan(0);
+      const headings = await page.getByRole("heading").all();
+      expect(headings.length).toBeGreaterThan(0);
 
-      for (let i = 0; i < count; i++) {
-        const text = await headings.nth(i).textContent();
+      for (const heading of headings) {
+        const text = await heading.textContent({ timeout: 5000 });
         expect(text?.trim().length).toBeGreaterThan(0);
       }
     });


### PR DESCRIPTION
## Summary
- Fixes the intermittently failing "admin sections have no empty headings" e2e test
- This test has been flaking across zh-CN, ja, de, es, fr, ko locales on main for weeks
- Root cause: counting headings before the page finishes hydrating, then accessing by index as the DOM shifts

## Changes
- Added `waitForLoadState("networkidle")` before inspecting headings
- Switched from `count()` + `nth(i)` loop to `.all()` resolved snapshot
- Reduced per-heading timeout from 15s to 5s (page is already loaded)

## Test plan
- [ ] CI e2e tests pass without the flaky admin-i18n failures
- [ ] Verify the test still catches genuinely empty headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)