### PR TITLE
chore(deps): bump brace-expansion to 5.0.6 (Dependabot #21)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4363,9 +4363,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4728,9 +4728,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5642,9 +5642,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Resolves **Dependabot alert #21** (medium severity): `brace-expansion` DoS where a large numeric range defeats the documented `max` protection — vulnerable range `>= 5.0.0, < 5.0.6`, patched in `5.0.6`.

## Investigation
The affected `brace-expansion@5.0.5` was a **transitive, dev/build-time** dependency via `minimatch@10`, pulled in by two tools:
- `eslint-config-next` → `typescript-eslint` → `@typescript-eslint/typescript-estree` (linting)
- `shadcn` → `ts-morph` → `@ts-morph/common` (component generator)

Neither ships in the runtime bundle, and the DoS requires a malicious glob with a huge numeric range reaching `minimatch` — which only sees trusted config here. So **real-world exploitability is negligible**, but the patch is a trivial bump.

## Fix
`npm update brace-expansion`:
- both nested `5.0.5` copies → **`5.0.6`** (patched)
- the unrelated v1 line (eslint's `minimatch@3`, which requires `^1`) → `1.1.13 → 1.1.15`, still non-vulnerable

A blanket `overrides` entry was deliberately avoided — it would force the legitimate v1 consumer to v5 and break `minimatch@3`.

## Verification
- `npm audit` → **0 vulnerabilities**
- Lockfile-only change (no `package.json` change); 9 insertions / 9 deletions, all brace-expansion version + integrity lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)