### PR TITLE
chore: add dependabot.yml with grouped npm, Actions, and docker ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,9 @@
 #   docker         docker/Dockerfile base image
 #
 # CI runs on GitHub-hosted runners (public repo), so bot PRs need no runner
-# variable. Release automation (auto-release.yml -> promote-stable.yml) keys
-# off merges to main; a merged dependency bump is a normal merge to it.
+# variable. auto-release.yml runs on every push to main and cuts a build tag,
+# so a merged dependency bump gets one like any other merge; promote-stable.yml
+# is manual (workflow_dispatch) and is not triggered by these merges.
 version: 2
 updates:
   - package-ecosystem: npm
@@ -22,7 +23,9 @@ updates:
       prefix: chore
       include: scope
     groups:
-      dev-tooling:
+      # All npm deps (runtime and dev alike): one PR per week for minor/patch
+      # bumps; majors still arrive individually.
+      npm-minor-patch:
         patterns:
           - '*'
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+# Dependency + Actions update automation. Until now Dependabot only opened
+# security-update PRs here (the "npm_and_yarn group" bumps); this config adds
+# routine version updates, grouped so they arrive as one PR per ecosystem per
+# week instead of a cascade of conflicting singles.
+#
+# Ecosystems:
+#   npm            root package.json + package-lock.json
+#   github-actions .github/workflows/*.yml
+#   docker         docker/Dockerfile base image
+#
+# CI runs on GitHub-hosted runners (public repo), so bot PRs need no runner
+# variable. Release automation (auto-release.yml -> promote-stable.yml) keys
+# off merges to main; a merged dependency bump is a normal merge to it.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      dev-tooling:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      ci-actions:
+        patterns:
+          - '*'
+
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml`. Until now Dependabot only opened security-update PRs here (the "npm_and_yarn group" bumps such as #161 and #162); this adds routine version updates, grouped so they arrive as one PR per ecosystem per week instead of a cascade of conflicting single-dependency PRs.

- `npm` at `/`: `npm-minor-patch` group (all npm dependencies, runtime and dev alike), minor/patch, limit 5; majors still arrive individually
- `github-actions` at `/`: `ci-actions` group, all updates
- `docker` at `/docker`: base-image bumps for the published image

CI runs on GitHub-hosted runners (public repo), so bot PRs need no runner variable. `auto-release.yml` runs on every push to `main` and cuts a build tag, so a merged dependency bump gets one like any other merge; `promote-stable.yml` is manual (`workflow_dispatch`) and is not triggered by these merges.

Closes #166

## Test Plan

- `python3 -c 'import yaml; yaml.safe_load(...)'` parses the file; `version: 2` and the three `updates` entries come back as expected.
- Structure copied from `personal-assistant/.github/dependabot.yml`, which is live and producing grouped PRs; the npm group was renamed here because sharetab has runtime dependencies (review follow-up).
- The `test` job (including the Playwright e2e run) is green on this PR after #169 cleared the production `npm audit` gate.
- After merge: the Dependabot "Recent update jobs" page should show one job per ecosystem. The scheduled `audit.yml` still audits dev dependencies and will keep failing on the dev-only `mysql2` findings until #170 is done.
